### PR TITLE
Polish the demo page to better show optical balance.

### DIFF
--- a/svg-set/gridicons-demo.css
+++ b/svg-set/gridicons-demo.css
@@ -37,7 +37,7 @@ body {
 
 #icons div {
 	width: 48px;
-	height: 72px;
+	height: 64px;
 	float: left;
 	padding: 6px 2px;
 	position: relative;
@@ -57,7 +57,7 @@ body {
 #icons div svg {
 	width: 48px;
 	height: 48px;
-	fill: #333;
+	fill: #000;
 }
 
 #icons div:hover svg {


### PR DESCRIPTION
Fixes #16.
- Darken icons.
- Show at 2x (48px) instead of 4x size.
- Show titles.
- Reduce paddings and adjust margins.
