### PR TITLE
New icon: Follow

### DIFF
--- a/svg/gridicons_follow.svg
+++ b/svg/gridicons_follow.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="24px"
+	 height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<g id="Guides">
+</g>
+<g id="Artwork">
+	<path d="M19,21H5c-1.1,0-2-0.9-2-2V5c0-1.1,0.9-2,2-2h14c1.1,0,2,0.9,2,2v14C21,20.1,20.1,21,19,21z"/>
+	<g>
+		<rect x="11" y="7" fill="#FFFFFF" width="2" height="10"/>
+		<rect x="7" y="11" fill="#FFFFFF" width="10" height="2"/>
+	</g>
+</g>
+</svg>

--- a/svg/gridicons_follow.svg
+++ b/svg/gridicons_follow.svg
@@ -5,10 +5,7 @@
 <g id="Guides">
 </g>
 <g id="Artwork">
-	<path d="M19,21H5c-1.1,0-2-0.9-2-2V5c0-1.1,0.9-2,2-2h14c1.1,0,2,0.9,2,2v14C21,20.1,20.1,21,19,21z"/>
-	<g>
-		<rect x="11" y="7" fill="#FFFFFF" width="2" height="10"/>
-		<rect x="7" y="11" fill="#FFFFFF" width="10" height="2"/>
-	</g>
+	<path d="M19,3H5C3.9,3,3,3.9,3,5v14c0,1.1,0.9,2,2,2h14c1.1,0,2-0.9,2-2V5C21,3.9,20.1,3,19,3z M17,13h-4v4h-2v-4H7v-2h4V7h2v4h4
+		V13z"/>
 </g>
 </svg>


### PR DESCRIPTION
Adds the follow icon.

![follow](https://cloud.githubusercontent.com/assets/618551/6421716/1917a642-be97-11e4-92cc-e8a8ac98341e.png)

At first, I was trying to come up with a clever icon for "follow blog" that involved the Reader icon somehow. It became really busy, and I couldn't think of a metaphor for "blog".

I remembered that we are now adopting the square to represent site/blog avatars in Calypso, so I figured that a plus inside of a square would be a good solution.
- [x] Add icon to the svg folder.
- [ ] Update .ai file.
- [ ] run grunt
