### PR TITLE
Gridicons React component: Default class name to an empty string

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -133,6 +133,7 @@ module.exports = function(grunt) {
 					"	mixins: [ React.addons.PureRenderMixin ],\n\n" +
 					"	getDefaultProps: function() {\n" +
 					"		return {\n" +
+					"			className: '',\n" +
 					"			size: 24\n" +
 					"		};\n" +
 					"	},\n\n" +

--- a/react/gridicon/index.jsx
+++ b/react/gridicon/index.jsx
@@ -9,6 +9,7 @@ var Gridicon = React.createClass( {
 
 	getDefaultProps: function() {
 		return {
+			className: '',
 			size: 24
 		};
 	},


### PR DESCRIPTION
This avoids having the class name end up as the string 'undefined' if it is not passed in as a prop.
