### PR TITLE
Adding Speaker icon

### DIFF
--- a/svg/gridicons-speaker.svg
+++ b/svg/gridicons-speaker.svg
@@ -1,30 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" id="speaker" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
-<g id="Adv._Guides">
-</g>
-<g id="Guides">
-</g>
-<g id="Artwork">
+<g>
+	<path fill="#231F20" d="M19,9v3v3c1.7,0,3-1.3,3-3S20.7,9,19,9z"/>
 	<g>
-		<defs>
-			<path id="SVGID_1_" d="M15,4h2v16h-2V4z M2,10c0-1.1,0.9-2,2-2h7l4-4v16c0,0-4-4-4-4H4c-1.1,0-2-0.9-2-2V10z M9,18v-2H5v3
-				c0,1.1,0.9,2,2,2h2V18z M19,15c1.7,0,3-1.3,3-3c0-1.7-1.3-3-3-3v3V15z"/>
-		</defs>
-		<clipPath id="SVGID_2_">
-			<use xlink:href="#SVGID_1_"  overflow="visible"/>
-		</clipPath>
-		<g clip-path="url(#SVGID_2_)">
-			<defs>
-				<rect id="SVGID_3_" x="-79" y="-13" width="105" height="40"/>
-			</defs>
-			<clipPath id="SVGID_4_">
-				<use xlink:href="#SVGID_3_"  overflow="visible"/>
-			</clipPath>
-			<rect x="-5" y="-1" clip-path="url(#SVGID_4_)" width="31" height="27"/>
-		</g>
+		<path fill="#231F20" d="M11,8H4c-1.1,0-2,0.9-2,2v4c0,1.1,0.9,2,2,2h1v3c0,1.1,0.9,2,2,2h2v-3v-2h2l4,4h2V4h-2L11,8z"/>
 	</g>
 </g>
 </svg>


### PR DESCRIPTION
This adds a new speaker icon:

![icon-speaker](https://cloud.githubusercontent.com/assets/57050/11402195/8418521c-938e-11e5-8fda-2f3b67a9b91e.png)

This is supposed to represent the ads section in the sidebar of WordPress.com, see it here in context:

![test_option_h_seleted](https://cloud.githubusercontent.com/assets/57050/11402236/b6f6fdd2-938e-11e5-9b17-bfb1da7a3a8d.png)

![test_option_h_unseleted](https://cloud.githubusercontent.com/assets/57050/11402237/b6f79a76-938e-11e5-9b42-19a47dcc3987.png)
