### PR TITLE
New icon: Product variable

### DIFF
--- a/svg/gridicons-product-variable.svg
+++ b/svg/gridicons-product-variable.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<g id="Adv._Guides">
+</g>
+<g id="Guides">
+</g>
+<g id="Artwork">
+	<g id="Layer_1_1_">
+	</g>
+	<g id="Layer_1_2_">
+	</g>
+	<g>
+		<path d="M20,2H4L2,6v16h20V6L20,2z M5.2,4h13.5l0.5,1H4.7L5.2,4z M20,20H4V7h16V20z"/>
+		<circle cx="15" cy="15" r="3"/>
+		<polygon points="9,12.6 6,18 12,18 		"/>
+		<path d="M11.1,14.3c0.3-1.9,2-3.3,3.9-3.3V9H9v1.5l0.9,1.6L11.1,14.3z"/>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
![product variable](https://cldup.com/hbuQCMzilt.thumb.png)

We've had various versions of this icon since WooCommerce 1.0 and have never really come up with something that _feels_ right. I've played on the 'types' icon that already exists in Gridicons but if anyone has a better idea I'm all ears :)
