### PR TITLE
New icon: Shipping classes

### DIFF
--- a/svg/gridicons-shipping-classes.svg
+++ b/svg/gridicons-shipping-classes.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<g id="Adv._Guides">
+</g>
+<g id="Guides">
+</g>
+<g id="Artwork">
+	<g>
+		<path d="M20,2h-6h-2l-2,3v1v1v1h2V7h8v13h-4v2h6V5L20,2z M14,5h-1.7L13,4h1h4.9l0.7,1H14z"/>
+		<path d="M10,10H6H4l-2,3v1v1v7h8h4v-2v-7l-2-3H10z M5,12h1h4h0.9l0.7,1H10H6H4.3L5,12z M10,20H4v-5h6h2v5H10z"/>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
![shipping classes](https://cldup.com/KJ8ejRRG2f.thumb.png)

Not entirely sure about this one. Would love some feedback.

"Shipping classes can be used to group products of similar type and can be used by some Shipping Methods (such as Flat Rate Shipping) to provide different rates to different classes of product."

The icon simply represents different types of products that might need different shipping rates.

¯_(ツ)_/¯
