### PR TITLE
New icon: Resize

### DIFF
--- a/svg/gridicons-bolt.svg
+++ b/svg/gridicons-bolt.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>gridicons-bolt</title><g id="Artwork"><polygon points="10.36 3 18 3 13.64 9 18 9 6 21 10.33 12 6 12 10.36 3"/></g></svg>

--- a/svg/gridicons-bolt.svg
+++ b/svg/gridicons-bolt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>gridicons-bolt</title><g id="Artwork"><polygon points="10.36 3 18 3 13.64 9 18 9 6 21 10.33 12 6 12 10.36 3"/></g></svg>

--- a/svg/gridicons-resize.svg
+++ b/svg/gridicons-resize.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>resize</title><g id="Artwork"><polygon points="13 4 13 6 16.59 6 10.79 11.79 6 16.59 6 13 4 13 4 20 11 20 11 18 7.41 18 12.21 13.21 18 7.41 18 11 20 11 20 4 13 4"/></g></svg>

--- a/svg/gridicons-resize.svg
+++ b/svg/gridicons-resize.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>gridicons-resize</title><g id="Artwork"><polygon points="13 4 13 6 16.59 6 10.79 11.79 6 16.59 6 13 4 13 4 20 11 20 11 18 7.41 18 12.21 13.21 18 7.41 18 11 20 11 20 4 13 4"/></g></svg>

--- a/svg/gridicons-resize.svg
+++ b/svg/gridicons-resize.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>resize</title><g id="Artwork"><polygon points="13 4 13 6 16.59 6 10.79 11.79 6 16.59 6 13 4 13 4 20 11 20 11 18 7.41 18 12.21 13.21 18 7.41 18 11 20 11 20 4 13 4"/></g></svg>


### PR DESCRIPTION
Sorry for the revert commits, but adding the Resize icon here as a separate pull request.

<img width="286" alt="resize" src="https://cloud.githubusercontent.com/assets/204742/16600179/e44ae074-42d3-11e6-8ff5-be24c4ba0423.png">

In context with other Gridicons:
<img width="343" alt="resize-in-context" src="https://cloud.githubusercontent.com/assets/204742/16600197/f0618dfe-42d3-11e6-9ce7-10bd4e69b318.png">
