### PR TITLE
Add support for older IE browsers

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -148,19 +148,20 @@ module.exports = function( grunt ) {
 					        }
 					    }
 					}
+
+					// SVG for Everybody
+					!function(a,b){"function"==typeof define&&define.amd?define([],function(){return a.svg4everybody=b()}):"object"==typeof module&&module.exports?module.exports=b():a.svg4everybody=b()}(this,function(){function a(a,b,c){if(c){var d=document.createDocumentFragment(),e=!b.hasAttribute("viewBox")&&c.getAttribute("viewBox");e&&b.setAttribute("viewBox",e);for(var f=c.cloneNode(!0);f.childNodes.length;)d.appendChild(f.firstChild);a.appendChild(d)}}function b(b){b.onreadystatechange=function(){if(4===b.readyState){var c=b._cachedDocument;c||(c=b._cachedDocument=document.implementation.createHTMLDocument(""),c.body.innerHTML=b.responseText,b._cachedTarget={}),b._embeds.splice(0).map(function(d){var e=b._cachedTarget[d.id];e||(e=b._cachedTarget[d.id]=c.getElementById(d.id)),a(d.parent,d.svg,e)})}},b.onreadystatechange()}function c(c){function e(){for(var c=0;c<m.length;){var h=m[c],i=h.parentNode,j=d(i);if(j){var n=h.getAttribute("xlink:href")||h.getAttribute("href");if(f&&(!g.validate||g.validate(n,j,h))){i.removeChild(h);var o=n.split("#"),p=o.shift(),q=o.join("#");if(p.length){var r=k[p];r||(r=k[p]=new XMLHttpRequest,r.open("GET",p),r.send(),r._embeds=[]),r._embeds.push({parent:i,svg:j,id:q}),b(r)}else a(i,document.getElementById(q))}}else++c}l(e,67)}var f,g=Object(c),h=/\bTrident\/[567]\b|\bMSIE (?:9|10)\.0\b/,i=/\bAppleWebKit\/(\d+)\b/,j=/\bEdge\/12\.(\d+)\b/;f="polyfill"in g?g.polyfill:h.test(navigator.userAgent)||(navigator.userAgent.match(j)||[])[1]<10547||(navigator.userAgent.match(i)||[])[1]<537;var k={},l=window.requestAnimationFrame||setTimeout,m=document.getElementsByTagName("use");f&&e()}function d(a){for(var b=a;"svg"!==b.nodeName.toLowerCase()&&(b=b.parentNode););return b}return c});svg4everybody();
 					</script>
 					</head>
 					<body>
 
 					<h1>Gridicons</h1>
 
-					{{{svg}}}
-
 					<div class="icons">
 					{{#each icons}}
 						<div>
 							<svg width="24" height="24" class="gridicon {{name}}">
-							<use xlink:href="#{{name}}" />
+							<use xlink:href="gridicons.svg#{{name}}" />
 							</svg>
 							<p>{{title}}</p>
 						</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -81,1270 +81,1021 @@ window.onload = function () {
         }
     }
 }
+
+// SVG for Everybody
+!function(a,b){"function"==typeof define&&define.amd?define([],function(){return a.svg4everybody=b()}):"object"==typeof module&&module.exports?module.exports=b():a.svg4everybody=b()}(this,function(){function a(a,b,c){if(c){var d=document.createDocumentFragment(),e=!b.hasAttribute("viewBox")&&c.getAttribute("viewBox");e&&b.setAttribute("viewBox",e);for(var f=c.cloneNode(!0);f.childNodes.length;)d.appendChild(f.firstChild);a.appendChild(d)}}function b(b){b.onreadystatechange=function(){if(4===b.readyState){var c=b._cachedDocument;c||(c=b._cachedDocument=document.implementation.createHTMLDocument(""),c.body.innerHTML=b.responseText,b._cachedTarget={}),b._embeds.splice(0).map(function(d){var e=b._cachedTarget[d.id];e||(e=b._cachedTarget[d.id]=c.getElementById(d.id)),a(d.parent,d.svg,e)})}},b.onreadystatechange()}function c(c){function e(){for(var c=0;c<m.length;){var h=m[c],i=h.parentNode,j=d(i);if(j){var n=h.getAttribute("xlink:href")||h.getAttribute("href");if(f&&(!g.validate||g.validate(n,j,h))){i.removeChild(h);var o=n.split("#"),p=o.shift(),q=o.join("#");if(p.length){var r=k[p];r||(r=k[p]=new XMLHttpRequest,r.open("GET",p),r.send(),r._embeds=[]),r._embeds.push({parent:i,svg:j,id:q}),b(r)}else a(i,document.getElementById(q))}}else++c}l(e,67)}var f,g=Object(c),h=/\bTrident\/[567]\b|\bMSIE (?:9|10)\.0\b/,i=/\bAppleWebKit\/(\d+)\b/,j=/\bEdge\/12\.(\d+)\b/;f="polyfill"in g?g.polyfill:h.test(navigator.userAgent)||(navigator.userAgent.match(j)||[])[1]<10547||(navigator.userAgent.match(i)||[])[1]<537;var k={},l=window.requestAnimationFrame||setTimeout,m=document.getElementsByTagName("use");f&&e()}function d(a){for(var b=a;"svg"!==b.nodeName.toLowerCase()&&(b=b.parentNode););return b}return c});svg4everybody();
 </script>
 </head>
 <body>
 
 <h1>Gridicons</h1>
 
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="width:0;height:0;visibility:hidden;"><symbol viewBox="0 0 24 24" id="gridicons-add-image"><title>gridicons-add-image</title> <g> <path d="M23,4v2h-3v3h-2V6h-3V4h3V1h2v3H23z M14.5,11c0.828,0,1.5-0.672,1.5-1.5S15.328,8,14.5,8S13,8.672,13,9.5
-		S13.672,11,14.5,11z M18,14.234l-0.513-0.57c-0.794-0.885-2.181-0.885-2.976,0l-0.656,0.731L9,9l-3,3.333V6h7V4H6
-		C4.895,4,4,4.895,4,6v12c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2v-7h-2V14.234z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-add-outline"><title>gridicons-add-outline</title> <g> <path d="M12,4c4.411,0,8,3.589,8,8s-3.589,8-8,8s-8-3.589-8-8S7.589,4,12,4 M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10
-		s10-4.477,10-10S17.523,2,12,2L12,2z M17,11h-4V7h-2v4H7v2h4v4h2v-4h4V11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-add"><title>gridicons-add</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10s10-4.477,10-10C22,6.477,17.523,2,12,2z M17,13h-4v4h-2v-4H7v-2h4V7h2
-		v4h4V13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-center"><title>gridicons-align-center</title> <g> <path d="M4,19h16v-2H4V19z M17,13H7v2h10V13z M4,9v2h16V9H4z M17,5H7v2h10V5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-image-center"><title>gridicons-align-image-center</title> <g> <path d="M3,5h18v2H3V5z M3,19h18v-2H3V19z M8,15h8V9H8V15z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-image-left"><title>gridicons-align-image-left</title> <g> <path d="M3,5h18v2H3V5z M3,19h18v-2H3V19z M3,15h8V9H3V15z M13,15h8v-2h-8V15z M13,11h8V9h-8V11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-image-none"><title>gridicons-align-image-none</title> <g> <path d="M21,7H3V5h18V7z M21,17H3v2h18V17z M11,9H3v6h8V9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-image-right"><title>gridicons-align-image-right</title> <g> <path d="M21,7H3V5h18V7z M21,17H3v2h18V17z M21,9h-8v6h8V9z M11,13H3v2h8V13z M11,9H3v2h8V9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-justify"><title>gridicons-align-justify</title> <g> <path d="M4,19h16v-2H4V19z M20,13H4v2h16V13z M4,9v2h16V9H4z M20,5L4,5v2h16V5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-left"><title>gridicons-align-left</title> <g> <path d="M4,19h16v-2H4V19z M14,13H4v2h10V13z M4,9v2h16V9H4z M14,5H4v2h10V5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-right"><title>gridicons-align-right</title> <g> <path d="M20,17H4v2h16V17z M10,15h10v-2H10V15z M4,9v2h16V9H4z M10,7h10V5H10V7z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-arrow-down"><title>gridicons-arrow-down</title> <g> <path d="M11,4v12.17l-5.59-5.59L4,12l8,8l8-8l-1.41-1.41L13,16.17V4H11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-arrow-left"><title>gridicons-arrow-left</title> <g> <path d="M20,11H7.83l5.59-5.59L12,4l-8,8l8,8l1.41-1.41L7.83,13H20V11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-arrow-right"><title>gridicons-arrow-right</title> <g> <path d="M12,4l-1.41,1.41L16.17,11H4v2h12.17l-5.58,5.59L12,20l8-8L12,4z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-arrow-up"><title>gridicons-arrow-up</title> <g> <path d="M13,20V7.83l5.59,5.59L20,12l-8-8l-8,8l1.41,1.41L11,7.83V20H13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-aside"><title>gridicons-aside</title> <g> <path d="M14,20l6-6V6c0-1.105-0.895-2-2-2H6C4.895,4,4,4.895,4,6v12c0,1.105,0.895,2,2,2H14z M6,6h12v6h-4c-1.105,0-2,0.895-2,2v4
-		H6V6z M16,10H8V8h8V10z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-attachment"><title>gridicons-attachment</title> <g> <path d="M14,1c-2.762,0-5,2.238-5,5v10c0,1.657,1.343,3,3,3c1.657,0,2.99-1.343,2.99-3V6H13v10c0,0.553-0.447,1-1,1
-		c-0.553,0-1-0.447-1-1V6c0-1.657,1.343-3,3-3c1.657,0,3,1.343,3,3v10.125C17,18.887,14.762,21,12,21c-2.762,0-5-2.238-5-5v-5H5v5
-		c0,3.866,3.134,7,7,7c3.866,0,6.99-3.134,6.99-7V6C18.99,3.238,16.762,1,14,1z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-audio"><title>gridicons-audio</title> <g> <path d="M8,4v10.184C7.686,14.072,7.353,14,7,14c-1.657,0-3,1.343-3,3s1.343,3,3,3s3-1.343,3-3V7h7v4.184
-		C16.686,11.072,16.353,11,16,11c-1.657,0-3,1.343-3,3s1.343,3,3,3s3-1.343,3-3V4H8z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-bell"><title>gridicons-bell</title> <g> <path d="M6.14,14.969l2.828,2.828c-0.362,0.362-0.862,0.586-1.414,0.586c-1.105,0-2-0.895-2-2
-		C5.555,15.831,5.778,15.331,6.14,14.969z M15.007,20.294L14.301,21L3,9.699l0.706-0.706L4.808,9.15
-		c0.754,0.108,1.689-0.122,2.077-0.51l3.885-3.884c2.34-2.34,6.135-2.34,8.475,0s2.34,6.135,0,8.475l-3.885,3.885
-		c-0.388,0.388-0.618,1.323-0.51,2.077L15.007,20.294z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-block"><title>gridicons-block</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10C22,6.477,17.523,2,12,2z M4,12
-		c0-4.418,3.582-8,8-8c1.848,0,3.545,0.633,4.9,1.686L5.686,16.9C4.633,15.545,4,13.848,4,12z M12,20
-		c-1.848,0-3.546-0.633-4.9-1.686L18.314,7.1C19.367,8.455,20,10.152,20,12C20,16.418,16.418,20,12,20z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-bold"><title>gridicons-bold</title> <g> <path d="M7,5.009h4.547c2.126,0,3.671,0.303,4.632,0.907c0.962,0.605,1.442,1.567,1.442,2.887c0,0.896-0.211,1.63-0.631,2.205
-		c-0.421,0.574-0.98,0.919-1.678,1.036v0.103c0.951,0.212,1.637,0.608,2.057,1.189C17.79,13.916,18,14.688,18,15.652
-		c0,1.367-0.494,2.434-1.482,3.199C15.529,19.617,14.186,20,12.491,20H7V5.009z M10,10.946h2.027c0.862,0,1.486-0.133,1.872-0.4
-		c0.387-0.267,0.579-0.708,0.579-1.323c0-0.574-0.21-0.986-0.63-1.236c-0.421-0.249-1.087-0.374-1.996-0.374H10V10.946z M10,13.469
-		v3.906h2.253c0.876,0,1.521-0.167,1.939-0.502c0.417-0.335,0.626-0.848,0.626-1.539c0-1.244-0.889-1.865-2.668-1.865H10z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-book"><title>gridicons-book</title> <g> <g> <g> <rect x="4" y="3" width="2" height="18"/> <path d="M18,3H7v18h11c1.1,0,2-0.9,2-2V5C20,3.9,19.1,3,18,3z M16,9h-6V8h6V9z M16,7h-6V6h6V7z"/> </g> </g> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-bookmark-outline"><title>gridicons-bookmark-outline</title> <g> <path d="M17,5v12.554l-5-2.857l-5,2.857V5H17 M17,3H7C5.895,3,5,3.896,5,5v16l7-4l7,4V5C19,3.896,18.104,3,17,3L17,3z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-bookmark"><title>gridicons-bookmark</title> <g> <path d="M17,3H7C5.895,3,5,3.896,5,5v16l7-4l7,4V5C19,3.896,18.104,3,17,3z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-briefcase"><title>gridicons-briefcase</title> <g> <path d="M14,15h-4v-2H2v6c0,1.105,0.895,2,2,2h16c1.105,0,2-0.895,2-2v-6h-8V15z M20,6h-2V4c0-1.105-0.895-2-2-2H8
-		C6.895,2,6,2.895,6,4v2H4C2.895,6,2,6.895,2,8v4h20V8C22,6.895,21.105,6,20,6z M16,6H8V4h8V6z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-calendar"><title>gridicons-calendar</title> <g> <path d="M19,4h-1V2h-2v2H8V2H6v2H5C3.895,4,3,4.896,3,6v13c0,1.104,0.895,2,2,2h14c1.104,0,2-0.896,2-2V6C21,4.896,20.104,4,19,4z
-		 M19,19H5V8h14V19z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-camera"><title>gridicons-camera</title> <g> <path d="M17,12c0,1.7-1.3,3-3,3s-3-1.3-3-3s1.3-3,3-3S17,10.3,17,12z M22,7v11c0,1.1-0.9,2-2,2H4c-1.1,0-2-0.9-2-2V7
-		c0-1.1,0.9-2,2-2V4h4v1h2l1-2h6l1,2h2C21.1,5,22,5.9,22,7z M7.5,9c0-0.8-0.7-1.5-1.5-1.5S4.5,8.2,4.5,9s0.7,1.5,1.5,1.5
-		S7.5,9.8,7.5,9z M19,12c0-2.8-2.2-5-5-5s-5,2.2-5,5s2.2,5,5,5S19,14.8,19,12z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-caption"><title>gridicons-caption</title> <g> <path d="M20,15l2-2v5c0,1.105-0.895,2-2,2H4c-1.105,0-2-0.895-2-2V6c0-1.105,0.895-2,2-2h13l-2,2H4v12h16V15z M22.44,6.44
-		l-0.88-0.88c-0.586-0.585-1.534-0.585-2.12,0L12,13v2H6v2h9v-1l7.44-7.44C23.025,7.974,23.025,7.026,22.44,6.44z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cart"><title>gridicons-cart</title> <g> <path d="M9,20c0,1.1-0.9,2-2,2s-1.99-0.9-1.99-2S5.9,18,7,18S9,18.9,9,20z M17,18c-1.1,0-1.99,0.9-1.99,2s0.89,2,1.99,2s2-0.9,2-2
-		S18.1,18,17,18z M17.396,13c0.937,0,1.749-0.651,1.952-1.566L21,5H7V4c0-1.105-0.895-2-2-2H3v2h2v1v8v2c0,1.105,0.895,2,2,2h12
-		c0-1.105-0.895-2-2-2H7v-2H17.396z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-chat"><title>gridicons-chat</title> <g> <path d="M20,4h-8c-1.1,0-2,0.9-2,2v2h2c1.7,0,3,1.3,3,3v2h2v3.5l3.3-2.3c1.1-0.8,1.7-2,1.7-3.3V6C22,4.9,21.1,4,20,4z"/> <g> <path d="M14,11v5c0,1.1-0.9,2-2,2H7v3.5l-3.3-2.3c-1.1-0.8-1.7-2-1.7-3.3V11c0-1.1,0.9-2,2-2h8C13.1,9,14,9.9,14,11z"/> </g> </g> </symbol><symbol viewBox="0 0 24 24" id="gridicons-checkmark-circle"><title>gridicons-checkmark-circle</title> <g> <path d="M11,17.768l-4.884-4.884l1.768-1.768L11,14.232l8.658-8.658C17.823,3.391,15.075,2,12,2C6.477,2,2,6.477,2,12
-		s4.477,10,10,10s10-4.477,10-10c0-1.528-0.353-2.971-0.966-4.266L11,17.768z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-checkmark"><title>gridicons-checkmark</title> <g> <polygon points="9,19.414 2.293,12.707 3.707,11.293 9,16.586 20.293,5.293 21.707,6.707 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-chevron-down"><title>gridicons-chevron-down</title> <g> <polygon points="20,9 12,17 4,9 5.414,7.586 12,14.172 18.586,7.586 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-chevron-left"><title>gridicons-chevron-left</title> <g> <polygon points="14,20 6,12 14,4 15.414,5.414 8.828,12 15.414,18.586 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-chevron-right"><title>gridicons-chevron-right</title> <g> <polygon points="10,20 18,12 10,4 8.586,5.414 15.172,12 8.586,18.586 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-chevron-up"><title>gridicons-chevron-up</title> <g> <polygon points="4,15 12,7 20,15 18.586,16.414 12,9.828 5.414,16.414 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-clear-formatting"><title>gridicons-clear-formatting</title> <g> <path d="M10.837,10.163l-4.6,4.6L10,4h4l0.777,2.223l-2.144,2.144l-0.627-2.092L10.837,10.163z M16.332,10.669L19.244,19H15.82
-		l-1.049-3.5H11.5L5,22l-1.5-1.5l17-17L22,5L16.332,10.669z M14.021,12.979l-0.031,0.031L14.022,13L14.021,12.979z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-clipboard"><title>gridicons-clipboard</title> <g> <path d="M16,18H8v-2h8V18z M16,12H8v2h8V12z M18,3h-2v2h2v15H6V5h2V3H6C4.895,3,4,3.895,4,5v15c0,1.105,0.895,2,2,2h12
-		c1.105,0,2-0.895,2-2V5C20,3.895,19.105,3,18,3z M14,5V4c0-1.105-0.895-2-2-2s-2,0.895-2,2v1C8.895,5,8,5.895,8,7v1h8V7
-		C16,5.895,15.105,5,14,5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cloud-download"><title>gridicons-cloud-download</title> <g> <path d="M18,9c-0.009,0-0.017,0.002-0.025,0.003C17.72,5.646,14.922,3,11.5,3C7.91,3,5,5.91,5,9.5c0,0.524,0.069,1.031,0.186,1.519
-		C5.123,11.016,5.064,11,5,11c-2.209,0-4,1.791-4,4c0,1.202,0.541,2.267,1.38,3h18.593C22.196,17.089,23,15.643,23,14
-		C23,11.239,20.761,9,18,9z M12,16l-4-5h3V8h2v3h3L12,16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cloud-outline"><title>gridicons-cloud-outline</title> <g> <path d="M11.5,5c2.336,0,4.304,1.825,4.481,4.154l0.141,1.861l1.867-0.013l0.093-0.001C19.698,11.044,21,12.373,21,14
-		c0,0.748-0.28,1.452-0.783,2H3.279C3.124,15.744,3,15.411,3,15c0-1.074,0.851-1.953,1.915-1.998
-		c0.059,0.007,0.118,0.012,0.178,0.015l2.659,0.124l-0.621-2.588C7.043,10.186,7,9.842,7,9.5C7,7.019,9.019,5,11.5,5 M11.5,3
-		C7.91,3,5,5.91,5,9.5c0,0.524,0.069,1.031,0.186,1.519C5.123,11.016,5.064,11,5,11c-2.209,0-4,1.791-4,4
-		c0,1.202,0.541,2.267,1.38,3h18.593C22.196,17.089,23,15.643,23,14c0-2.761-2.239-5-5-5c-0.009,0-0.017,0.002-0.025,0.002
-		C17.72,5.646,14.922,3,11.5,3L11.5,3z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cloud-upload"><title>gridicons-cloud-upload</title> <g> <path d="M18,9c-0.009,0-0.017,0.002-0.025,0.003C17.72,5.646,14.922,3,11.5,3C7.91,3,5,5.91,5,9.5c0,0.524,0.069,1.031,0.186,1.519
-		C5.123,11.016,5.064,11,5,11c-2.209,0-4,1.791-4,4c0,1.202,0.541,2.267,1.38,3h18.593C22.196,17.089,23,15.643,23,14
-		C23,11.239,20.761,9,18,9z M13,13v3h-2v-3H8l4-5l4,5H13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cloud"><title>gridicons-cloud</title> <g> <path d="M18,9c-0.009,0-0.017,0.002-0.025,0.003C17.72,5.646,14.922,3,11.5,3C7.91,3,5,5.91,5,9.5c0,0.524,0.069,1.031,0.186,1.519
-		C5.123,11.016,5.064,11,5,11c-2.209,0-4,1.791-4,4c0,1.202,0.541,2.267,1.38,3h18.593C22.196,17.089,23,15.643,23,14
-		C23,11.239,20.761,9,18,9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-code"><title>gridicons-code</title> <g> <path d="M4.83,12l4.58,4.59L8,18l-6-6l6-6l1.41,1.41L4.83,12z M14.59,16.59L16,18l6-6l-6-6l-1.41,1.41L19.17,12L14.59,16.59z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cog"><title>gridicons-cog</title> <g> <path d="M20,12c0-0.568-0.061-1.122-0.174-1.656l1.834-1.612l-2-3.464l-2.322,0.786c-0.819-0.736-1.787-1.308-2.859-1.657L14,2h-4
-		L9.521,4.396c-1.072,0.349-2.04,0.921-2.859,1.657L4.34,5.268l-2,3.464l1.834,1.612C4.061,10.878,4,11.432,4,12
-		s0.061,1.122,0.174,1.656L2.34,15.268l2,3.464l2.322-0.786c0.819,0.736,1.787,1.308,2.859,1.657L10,22h4l0.479-2.396
-		c1.072-0.349,2.039-0.921,2.859-1.657l2.322,0.786l2-3.464l-1.834-1.612C19.939,13.122,20,12.568,20,12z M12,16
-		c-2.209,0-4-1.791-4-4c0-2.209,1.791-4,4-4c2.209,0,4,1.791,4,4C16,14.209,14.209,16,12,16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-comment"><title>gridicons-comment</title> <g> <path d="M3,6v9c0,1.105,0.895,2,2,2h9v5l5.325-3.804C20.376,17.446,21,16.233,21,14.942V6c0-1.105-0.895-2-2-2H5
-		C3.895,4,3,4.895,3,6z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-computer"><title>gridicons-computer</title> <g> <path d="M20,2H4C2.896,2,2,2.896,2,4v12c0,1.104,0.896,2,2,2h6l0,2H7v2h10v-2h-3l0-2h6c1.104,0,2-0.896,2-2V4
-		C22,2.896,21.104,2,20,2z M20,16H4V4h16V16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-coupon"><title>gridicons-coupon</title> <g> <path d="M13,16v2h-2v-2H13z M16,13h2v-2h-2V13z M18,21h-2v2h2V21z M21,16v2h2v-2H21z M20,13c0.552,0,1,0.448,1,1h2
-		c0-1.657-1.343-3-3-3V13z M21,20c0,0.552-0.448,1-1,1v2c1.657,0,3-1.343,3-3H21z M14,21c-0.552,0-1-0.448-1-1h-2
-		c0,1.657,1.343,3,3,3V21z M17.21,15.79c-0.781,0.781-2.047,0.782-2.828,0.002c-0.001-0.001-0.001-0.001-0.002-0.002L10,11.41
-		l-1.43,1.44C8.849,13.356,8.997,13.923,9,14.5C9,16.433,7.433,18,5.5,18S2,16.433,2,14.5S3.567,11,5.5,11
-		c0.577,0.003,1.144,0.151,1.65,0.43L8.59,10L7.15,8.57C6.644,8.849,6.077,8.997,5.5,9C3.567,9,2,7.433,2,5.5S3.567,2,5.5,2
-		S9,3.567,9,5.5C8.997,6.077,8.849,6.644,8.57,7.15L10,8.59l3.88-3.88c0.781-0.781,2.047-0.782,2.828-0.002
-		c0.001,0.001,0.001,0.001,0.002,0.002L11.41,10L17.21,15.79z M5.5,7C6.328,7,7,6.328,7,5.5S6.328,4,5.5,4S4,4.672,4,5.5
-		S4.672,7,5.5,7z M7,14.5C7,13.672,6.328,13,5.5,13S4,13.672,4,14.5S4.672,16,5.5,16S7,15.328,7,14.5L7,14.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-create"><title>gridicons-create</title> <g> <path d="M21,11v8c0,1.105-0.895,2-2,2H5c-1.105,0-2-0.895-2-2V5c0-1.105,0.895-2,2-2h8l-2,2H5v14h14v-6L21,11z M7,17h3l7.5-7.5
-		l-3-3L7,14V17z M16.939,4.061L15.5,5.5l3,3l1.439-1.439c0.586-0.586,0.586-1.536,0-2.121l-0.879-0.879
-		C18.475,3.475,17.525,3.475,16.939,4.061z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-credit-card"><title>gridicons-credit-card</title> <g> <path d="M20,4H4C2.895,4,2,4.895,2,6v12c0,1.105,0.895,2,2,2h16c1.105,0,2-0.895,2-2V6C22,4.895,21.105,4,20,4z M20,6v2H4V6H20z
-		 M4,18v-6h16v6H4z M6,14h7v2H6V14z M15,14h3v2h-3V14z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-crop"><title>gridicons-crop</title> <g> <path d="M22,16h-4V8c0-1.105-0.895-2-2-2H8V2H6v4H2v2h4v8c0,1.105,0.895,2,2,2h8v4h2v-4h4V16z M8,16V8h8v8H8z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cross-circle"><title>gridicons-cross-circle</title> <g> <path d="M19.1,4.9C15.2,1,8.8,1,4.9,4.9S1,15.2,4.9,19.1s10.2,3.9,14.1,0S23,8.8,19.1,4.9z M14.8,16.2L12,13.4l-2.8,2.8l-1.4-1.4
-		l2.8-2.8L7.8,9.2l1.4-1.4l2.8,2.8l2.8-2.8l1.4,1.4L13.4,12l2.8,2.8L14.8,16.2z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cross-small"><title>gridicons-cross-small</title> <g> <path d="M17.705,7.705l-1.41-1.41L12,10.59L7.705,6.295l-1.41,1.41L10.59,12l-4.295,4.295l1.41,1.41L12,13.41l4.295,4.295
-		l1.41-1.41L13.41,12L17.705,7.705z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cross"><title>gridicons-cross</title><g><path d="M18.36,19.78L12,13.41,5.64,19.78,4.22,18.36,10.59,12,4.22,5.64,5.64,4.22,12,10.59l6.36-6.36,1.41,1.41L13.41,12l6.36,6.36Z"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-custom-post-type"><title>gridicons-custom-post-type</title> <g> <path d="M19,3H5C3.895,3,3,3.895,3,5v14c0,1.105,0.895,2,2,2h14c1.105,0,2-0.895,2-2V5C21,3.895,20.105,3,19,3z M6,6h5v5H6V6z
-		 M10.5,19C9.119,19,8,17.881,8,16.5S9.119,14,10.5,14c1.381,0,2.5,1.119,2.5,2.5S11.881,19,10.5,19z M13.5,13l3-5l3,5H13.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-customize"><title>gridicons-customize</title> <g> <path d="M2,6c0-1.505,0.78-3.08,2-4c0,0.845,0.69,2,2,2c1.657,0,3,1.343,3,3c0,0.386-0.079,0.752-0.212,1.091
-		c0.739,0.593,1.476,1.188,2.191,1.808l-2.08,2.08c-0.62-0.715-1.215-1.453-1.808-2.191C6.752,9.921,6.386,10,6,10
-		C3.79,10,2,8.21,2,6z M14.152,12.848l1.341-1.341C16.099,11.812,16.775,12,17.5,12c2.485,0,4.5-2.015,4.5-4.5
-		c0-0.725-0.188-1.401-0.493-2.007L18,9l-2-2l3.507-3.507C18.901,3.188,18.225,3,17.5,3C15.015,3,13,5.015,13,7.5
-		c0,0.725,0.188,1.401,0.493,2.007L3,20l2,2l6.848-6.848c1.885,1.928,3.874,3.753,5.977,5.449l1.425,1.149l1.5-1.5l-1.149-1.425
-		C17.905,16.722,16.08,14.733,14.152,12.848z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-domains"><title>gridicons-domains</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10s10-4.477,10-10C22,6.477,17.523,2,12,2z M18.918,8h-3.215
-		c-0.188-1.424-0.42-2.651-0.565-3.357C16.731,5.325,18.054,6.513,18.918,8z M13.014,4.072C13.082,4.424,13.401,6.11,13.659,8
-		h-3.318c0.258-1.89,0.577-3.576,0.645-3.928C11.319,4.029,11.656,4,12,4S12.681,4.029,13.014,4.072z M14,12
-		c0,0.598-0.043,1.286-0.109,2h-3.782C10.043,13.286,10,12.598,10,12s0.043-1.286,0.109-2h3.782C13.957,10.714,14,11.402,14,12z
-		 M8.862,4.643C8.717,5.349,8.485,6.576,8.297,8H5.082C5.946,6.513,7.269,5.325,8.862,4.643z M4.263,10h3.821
-		C8.033,10.668,8,11.344,8,12s0.033,1.332,0.085,2H4.263C4.097,13.359,4,12.692,4,12S4.098,10.641,4.263,10z M5.082,16h3.215
-		c0.188,1.424,0.42,2.65,0.565,3.357C7.269,18.675,5.946,17.487,5.082,16z M10.986,19.928c-0.068-0.353-0.388-2.038-0.645-3.928
-		h3.318c-0.258,1.89-0.577,3.576-0.645,3.928C12.681,19.971,12.344,20,12,20S11.319,19.971,10.986,19.928z M15.138,19.357
-		c0.145-0.707,0.377-1.933,0.565-3.357h3.215C18.054,17.487,16.731,18.675,15.138,19.357z M19.737,14h-3.821
-		C15.967,13.332,16,12.656,16,12s-0.033-1.332-0.085-2h3.821C19.902,10.641,20,11.308,20,12S19.903,13.359,19.737,14z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-dropdown"><title>gridicons-dropdown</title> <g> <polygon points="7,10 12,15 17,10 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-ellipsis-circle"><title>gridicons-ellipsis-circle</title> <g> <path d="M12,2C6.5,2,2,6.5,2,12s4.5,10,10,10s10-4.5,10-10S17.5,2,12,2z M7.5,13.5C6.7,13.5,6,12.8,6,12s0.7-1.5,1.5-1.5
-		S9,11.2,9,12S8.3,13.5,7.5,13.5z M12,13.5c-0.8,0-1.5-0.7-1.5-1.5s0.7-1.5,1.5-1.5s1.5,0.7,1.5,1.5S12.8,13.5,12,13.5z M16.5,13.5
-		c-0.8,0-1.5-0.7-1.5-1.5s0.7-1.5,1.5-1.5c0.8,0,1.5,0.7,1.5,1.5S17.3,13.5,16.5,13.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-ellipsis"><title>gridicons-ellipsis</title> <g> <path d="M7,12c0,1.104-0.896,2-2,2s-2-0.896-2-2s0.896-2,2-2S7,10.896,7,12z M19,10c-1.104,0-2,0.896-2,2s0.896,2,2,2s2-0.896,2-2
-		S20.104,10,19,10z M12,10c-1.104,0-2,0.896-2,2s0.896,2,2,2s2-0.896,2-2S13.104,10,12,10z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-external"><title>gridicons-external</title> <g> <path d="M19,13v6c0,1.105-0.895,2-2,2H5c-1.105,0-2-0.895-2-2V7c0-1.105,0.895-2,2-2h6v2H5v12h12v-6H19z M13,3v2h4.586
-		l-7.793,7.793l1.414,1.414L19,6.414V11h2V3H13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-filter"><title>gridicons-filter</title> <g> <g> <path d="M18.595,4H5.415C4.863,3.997,4.412,4.442,4.409,4.994C4.408,5.263,4.514,5.521,4.705,5.71l5.3,5.29v6l4,4V11l5.29-5.29
-			c0.392-0.389,0.395-1.022,0.006-1.414C19.114,4.108,18.86,4.001,18.595,4z"/> </g> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-flag"><title>gridicons-flag</title> <g> <path d="M15,6c0-1.105-0.895-2-2-2H5v17h2v-7h5c0,1.105,0.895,2,2,2h6V6H15z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-flip-horizontal"><title>gridicons-flip-horizontal</title> <g> <path d="M20,18v-5h3v-2h-3V6c0-1.105-0.895-2-2-2H6C4.895,4,4,4.895,4,6v5H1v2h3v5c0,1.105,0.895,2,2,2h12
-		C19.105,20,20,19.105,20,18z M6,6h12v5H6V6z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-flip-vertical"><title>gridicons-flip-vertical</title> <g> <path d="M18,4h-5V1h-2v3H6C4.895,4,4,4.895,4,6v12c0,1.105,0.895,2,2,2h5v3h2v-3h5c1.105,0,2-0.895,2-2V6C20,4.895,19.105,4,18,4z
-		 M6,18V6h5v12H6z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-folder-multiple"><title>gridicons-folder-multiple</title> <g> <path d="M4,8L4,8c-1.105,0-2,0.895-2,2v10c0,1.1,0.9,2,2,2h14c1.105,0,2-0.895,2-2v0H4V8z M20,18H8c-1.105,0-2-0.895-2-2V6
-		c0-1.105,0.895-2,2-2h3c1.105,0,2,0.895,2,2v0h7c1.105,0,2,0.895,2,2v8C22,17.105,21.105,18,20,18z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-folder"><title>gridicons-folder</title> <g> <path d="M18,19H6c-1.1,0-2-0.9-2-2V7c0-1.1,0.9-2,2-2h3c1.1,0,2,0.9,2,2l0,0h7c1.1,0,2,0.9,2,2v8C20,18.1,19.1,19,18,19z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-fullscreen-exit"><title>gridicons-fullscreen-exit</title><g><path d="M14,10V4h2V6.59l3.29-3.29,1.41,1.41L17.41,8H20v2ZM4,10V8H6.59L3.29,4.71,4.71,3.29,8,6.59V4h2v6Zm16,4v2H17.41l3.29,3.29-1.41,1.41L16,17.41V20H14V14ZM10,14v6H8V17.41L4.71,20.71,3.29,19.29,6.59,16H4V14Z"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-fullscreen"><title>gridicons-fullscreen</title><g><path d="M21,3V9H19V6.41L15.71,9.71,14.29,8.29,17.59,5H15V3ZM3,3V9H5V6.41L8.29,9.71,9.71,8.29,6.41,5H9V3ZM21,21V15H19v2.59l-3.29-3.29-1.41,1.41L17.59,19H15v2ZM9,21V19H6.41l3.29-3.29L8.29,14.29,5,17.59V15H3v6Z"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-globe"><title>gridicons-globe</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10s10-4.477,10-10C22,6.477,17.523,2,12,2z M12,20l2-2l1-1v-2h-2v-1l-1-1
-		H9v3l2,2v1.931C7.06,19.436,4,16.072,4,12l1,1h2v-2h2l3-3V6h-2L9,5V4.589C9.927,4.212,10.939,4,12,4s2.073,0.212,3,0.589V6l-1,1v2
-		l1,1l3.13-3.13c0.752,0.897,1.304,1.964,1.606,3.13H18l-2,2v2l1,1h2l0.286,0.286C18.029,18.061,15.239,20,12,20z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-grid"><title>gridicons-grid</title> <g> <path d="M8,8H4V4h4V8z M14,4h-4v4h4V4z M20,4h-4v4h4V4z M8,10H4v4h4V10z M14,10h-4v4h4V10z M20,10h-4v4h4V10z M8,16H4v4h4V16z
-		 M14,16h-4v4h4V16z M20,16h-4v4h4V16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-heading"><title>gridicons-heading</title> <g> <path d="M18,20h-3v-6H9v6H6V5.009h3V11h6V5.009h3V20z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-heart-outline"><title>gridicons-heart-outline</title> <g> <path d="M16.5,4.5c2.206,0,4,1.794,4,4c0,4.669-5.543,8.941-8.5,11.023C9.043,17.441,3.5,13.169,3.5,8.5c0-2.206,1.794-4,4-4
-		c1.298,0,2.522,0.638,3.273,1.706L12,7.953l1.227-1.746C13.978,5.138,15.202,4.5,16.5,4.5 M16.5,3c-1.862,0-3.505,0.928-4.5,2.344
-		C11.005,3.928,9.362,3,7.5,3C4.462,3,2,5.462,2,8.5c0,5.719,6.5,10.438,10,12.85c3.5-2.412,10-7.131,10-12.85
-		C22,5.462,19.538,3,16.5,3L16.5,3z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-heart"><title>gridicons-heart</title> <g> <path d="M16.5,3c-1.862,0-3.505,0.928-4.5,2.344C11.005,3.928,9.362,3,7.5,3C4.462,3,2,5.462,2,8.5c0,5.719,6.5,10.438,10,12.85
-		c3.5-2.412,10-7.131,10-12.85C22,5.462,19.538,3,16.5,3z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-help-outline"><title>gridicons-help-outline</title> <g> <path d="M12,4c4.411,0,8,3.589,8,8s-3.589,8-8,8s-8-3.589-8-8S7.589,4,12,4 M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10
-		s10-4.477,10-10S17.523,2,12,2L12,2z M16,10c0-2.209-1.791-4-4-4s-4,1.791-4,4h2c0-1.103,0.897-2,2-2s2,0.897,2,2s-0.897,2-2,2
-		c-0.552,0-1,0.448-1,1v2h2v-1.141C14.722,13.413,16,11.862,16,10z M13,16h-2v2h2V16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-help"><title>gridicons-help</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10s10-4.477,10-10S17.523,2,12,2z M13,18h-2v-2h2V18z M13,13.859V15h-2v-2
-		c0-0.552,0.448-1,1-1c1.103,0,2-0.897,2-2s-0.897-2-2-2s-2,0.897-2,2H8c0-2.209,1.791-4,4-4s4,1.791,4,4
-		C16,11.862,14.722,13.413,13,13.859z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-history"><title>gridicons-history</title> <g> <g> <path d="M2.12,13.526c0.742,4.781,4.902,8.47,9.881,8.47c5.499,0,9.998-4.499,9.998-9.998S17.501,2,12.002,2
-			C8.704,2,5.802,3.601,4,6l0,0V2.001L2.003,2L2,9h7V7L5.801,6.999l0,0C7.2,5.201,9.502,4,12.002,4C16.4,4,20,7.6,20,11.998
-			s-3.6,7.999-7.999,7.999c-3.878,0-7.132-2.794-7.849-6.471L2.12,13.526z"/> <polygon points="11.002,6.999 11.002,12.301 14.203,16.598 15.803,15.401 13.002,11.7 13.002,6.999 		"/> </g> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-house"><title>gridicons-house</title> <g> <path d="M22,9L12,1L2,9v2h2v10h5v-4c0-1.657,1.343-3,3-3s3,1.343,3,3v4h5V11h2V9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-image-multiple"><title>gridicons-image-multiple</title> <g> <path d="M15,7.5C15,6.672,15.672,6,16.5,6C17.328,6,18,6.672,18,7.5S17.328,9,16.5,9C15.672,9,15,8.328,15,7.5z M4,20h14v0
-		c0,1.105-0.895,2-2,2H4c-1.1,0-2-0.9-2-2V8c0-1.105,0.895-2,2-2h0V20z M22,4v12c0,1.105-0.895,2-2,2H8c-1.105,0-2-0.895-2-2V4
-		c0-1.105,0.895-2,2-2h12C21.105,2,22,2.895,22,4z M8,4v6.333L11,7l4.855,5.395l0.656-0.731c0.795-0.885,2.182-0.885,2.976,0
-		L20,12.234V4H8z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-image"><title>gridicons-image</title> <g> <path d="M13,9.5C13,8.672,13.672,8,14.5,8S16,8.672,16,9.5S15.328,11,14.5,11S13,10.328,13,9.5z M22,6v12c0,1.105-0.895,2-2,2H4
-		c-1.105,0-2-0.895-2-2V6c0-1.105,0.895-2,2-2h16C21.105,4,22,4.895,22,6z M20,6H4v7.444L8,9l5.895,6.55l1.587-1.851
-		c0.798-0.931,2.239-0.931,3.037,0L20,15.427V6z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-indent-left"><title>gridicons-indent-left</title> <g> <path d="M18,20h2V4h-2V20z M2,11h10.172l-2.086-2.086L11.5,7.5L16,12l-4.5,4.5l-1.414-1.414L12.172,13H2V11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-indent-right"><title>gridicons-indent-right</title> <g> <path d="M6,4H4v16h2V4z M22,13H11.828l2.086,2.086L12.5,16.5L8,12l4.5-4.5l1.414,1.414L11.828,11H22V13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-info-outline"><title>gridicons-info-outline</title> <g> <path d="M13,9h-2V7h2V9z M13,11h-2v6h2V11z M12,4c-4.411,0-8,3.589-8,8s3.589,8,8,8s8-3.589,8-8S16.411,4,12,4 M12,2
-		c5.523,0,10,4.477,10,10s-4.477,10-10,10S2,17.523,2,12S6.477,2,12,2L12,2z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-info"><title>gridicons-info</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10s10-4.477,10-10S17.523,2,12,2z M13,17h-2v-6h2V17z M13,9h-2V7h2V9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-ink"><title>gridicons-ink</title> <g> <path d="M5,15c0,3.866,3.134,7,7,7s7-3.134,7-7c0-1.387-0.409-2.677-1.105-3.765h0.007C15.542,7.541,12,2,12,2
-		s-3.542,5.541-5.903,9.235h0.007C5.409,12.323,5,13.613,5,15z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-institution"><title>gridicons-institution</title> <g> <g> <g> <rect x="2" y="19" width="20" height="3"/> <polygon points="12,2 2,6 2,8 22,8 22,6 			"/> <rect x="17" y="10" width="3" height="7"/> <rect x="10.5" y="10" width="3" height="7"/> <rect x="4" y="10" width="3" height="7"/> </g> </g>  </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-italic"><title>gridicons-italic</title> <g> <polygon points="10.536,5 10.109,7 11.609,7 9.263,18 7.763,18 7.336,20 13.464,20 13.89,18 12.39,18 14.737,7 16.237,7 16.664,5 	
-		"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-layout-blocks"><title>gridicons-layout-blocks</title> <g> <path d="M21,7h-2V3c0-1.105-0.895-2-2-2H7C5.895,1,5,1.895,5,3v2H3C1.895,5,1,5.895,1,7v4c0,1.105,0.895,2,2,2h2v8
-		c0,1.105,0.895,2,2,2h10c1.105,0,2-0.895,2-2v-2h2c1.105,0,2-0.895,2-2V9C23,7.895,22.105,7,21,7z M17,21H7v-8h2
-		c1.105,0,2-0.895,2-2V7c0-1.105-0.895-2-2-2H7V3h10v4h-2c-1.105,0-2,0.895-2,2v8c0,1.105,0.895,2,2,2h2V21z M21,17h-6V9h6V17z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-layout"><title>gridicons-layout</title> <g> <path d="M8,20H5c-1.105,0-2-0.895-2-2V6c0-1.105,0.895-2,2-2h3c1.105,0,2,0.895,2,2v12C10,19.105,9.105,20,8,20z M16,10h4
-		c1.105,0,2-0.895,2-2V5c0-1.105-0.895-2-2-2h-4c-1.105,0-2,0.895-2,2v3C14,9.105,14.895,10,16,10z M21,20v-6c0-1.105-0.895-2-2-2
-		h-5c-1.105,0-2,0.895-2,2v6c0,1.105,0.895,2,2,2h5C20.105,22,21,21.105,21,20z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-link-break"><title>gridicons-link-break</title> <g> <path d="M10,11l-2,2H7v-2H10z M19.641,7.36L22,5l-1.5-1.5l-17,17L5,22l9-9h3v-2h-1l2-2c1.103,0,2,0.897,2,2v2c0,1.103-0.897,2-2,2
-		h-1h-3.977c0.913,1.208,2.347,2,3.977,2h1c2.209,0,4-1.791,4-4v-2C22,9.377,21.029,7.987,19.641,7.36z M4.36,16.64L6,15
-		c-1.103,0-2-0.897-2-2v-2c0-1.103,0.897-2,2-2h1h3.977C10.065,7.792,8.631,7,7,7H6c-2.209,0-4,1.791-4,4v2
-		C2,14.623,2.971,16.013,4.36,16.64z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-link"><title>gridicons-link</title> <g> <path d="M17,13H7v-2h10V13z M18,7h-1c-1.631,0-3.065,0.792-3.977,2H17h1c1.103,0,2,0.897,2,2v2c0,1.103-0.897,2-2,2h-1h-3.977
-		c0.913,1.208,2.347,2,3.977,2h1c2.209,0,4-1.791,4-4v-2C22,8.791,20.209,7,18,7z M2,11v2c0,2.209,1.791,4,4,4h1
-		c1.63,0,3.065-0.792,3.977-2H7H6c-1.103,0-2-0.897-2-2v-2c0-1.103,0.897-2,2-2h1h3.977C10.065,7.792,8.631,7,7,7H6
-		C3.791,7,2,8.791,2,11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-list-checkmark"><title>gridicons-list-checkmark</title> <g> <path d="M9.5,15.5L5,20l-2.5-2.5l1.061-1.061L5,17.879l3.439-3.439L9.5,15.5z M10,5v2h11V5H10z M10,19h11v-2H10V19z M10,13h11v-2
-		H10V13z M5,15 M8.439,8.439L5,11.879l-1.439-1.439L2.5,11.5L5,14l4.5-4.5L8.439,8.439z M8.439,2.439L5,5.879L3.561,4.439L2.5,5.5
-		L5,8l4.5-4.5L8.439,2.439z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-list-ordered"><title>gridicons-list-ordered</title> <g> <path d="M8,19h13v-2H8V19z M8,13h13v-2H8V13z M8,5v2h13V5H8z M3.575,5.252c0.107-0.096,0.197-0.188,0.269-0.275
-		c-0.012,0.228-0.018,0.48-0.018,0.756V8h1.175V3.717H3.959L2.488,4.915l0.601,0.738L3.575,5.252z M3.909,13.016
-		c0.475-0.426,0.785-0.715,0.93-0.867c0.146-0.152,0.262-0.297,0.35-0.435c0.088-0.138,0.153-0.278,0.195-0.42
-		c0.042-0.143,0.063-0.298,0.063-0.466c0-0.225-0.06-0.427-0.18-0.608S4.978,9.9,4.76,9.803C4.542,9.704,4.295,9.655,4.018,9.655
-		c-0.221,0-0.419,0.022-0.596,0.067s-0.34,0.11-0.491,0.195c-0.15,0.085-0.336,0.226-0.557,0.423l0.636,0.744
-		c0.174-0.15,0.33-0.264,0.467-0.341c0.138-0.077,0.274-0.116,0.409-0.116c0.131,0,0.233,0.032,0.305,0.097
-		c0.072,0.064,0.108,0.152,0.108,0.264c0,0.09-0.018,0.176-0.054,0.258c-0.036,0.082-0.1,0.18-0.192,0.294
-		c-0.092,0.114-0.287,0.328-0.586,0.64l-1.046,1.058V14h3.108v-0.955h-1.62L3.909,13.016L3.909,13.016z M4.439,17.762v-0.018
-		c0.307-0.086,0.541-0.225,0.703-0.414c0.162-0.191,0.243-0.419,0.243-0.685c0-0.309-0.126-0.551-0.378-0.727
-		c-0.252-0.176-0.6-0.264-1.043-0.264c-0.307,0-0.579,0.033-0.816,0.1s-0.469,0.178-0.696,0.334l0.48,0.773
-		c0.293-0.184,0.576-0.275,0.85-0.275c0.147,0,0.263,0.027,0.35,0.082s0.13,0.139,0.13,0.252c0,0.301-0.294,0.451-0.882,0.451H3.11
-		v0.87h0.264c0.217,0,0.393,0.016,0.527,0.049c0.135,0.031,0.232,0.08,0.293,0.143c0.061,0.064,0.091,0.154,0.091,0.271
-		c0,0.152-0.058,0.264-0.174,0.336c-0.116,0.07-0.301,0.106-0.555,0.106c-0.164,0-0.343-0.022-0.538-0.069
-		c-0.194-0.045-0.385-0.116-0.573-0.212v0.961c0.228,0.088,0.441,0.148,0.637,0.182c0.196,0.033,0.41,0.05,0.64,0.05
-		c0.561,0,0.998-0.114,1.314-0.343c0.315-0.228,0.473-0.542,0.473-0.94C5.512,18.19,5.154,17.852,4.439,17.762z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-list-unordered"><title>gridicons-list-unordered</title> <g> <path d="M9,19h12v-2H9V19z M9,13h12v-2H9V13z M9,5v2h12V5H9z M5,4.5C4.172,4.5,3.5,5.172,3.5,6S4.172,7.5,5,7.5S6.5,6.828,6.5,6
-		S5.828,4.5,5,4.5z M5,10.5c-0.828,0-1.5,0.672-1.5,1.5s0.672,1.5,1.5,1.5s1.5-0.672,1.5-1.5S5.828,10.5,5,10.5z M5,16.5
-		c-0.828,0-1.5,0.672-1.5,1.5s0.672,1.5,1.5,1.5s1.5-0.672,1.5-1.5S5.828,16.5,5,16.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-location"><title>gridicons-location</title> <g> <path d="M19,9c0-3.866-3.134-7-7-7S5,5.134,5,9c0,1.387,0.409,2.677,1.105,3.765H6.097C8.458,16.459,12,22,12,22
-		s3.542-5.541,5.903-9.235h-0.007C18.591,11.677,19,10.387,19,9z M12,12c-1.657,0-3-1.343-3-3s1.343-3,3-3s3,1.343,3,3
-		S13.657,12,12,12z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-lock"><title>gridicons-lock</title> <g> <path d="M18,8h-1V7c0-2.757-2.243-5-5-5S7,4.243,7,7v1H6c-1.105,0-2,0.895-2,2v10c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V10
-		C20,8.895,19.105,8,18,8z M9,7c0-1.654,1.346-3,3-3s3,1.346,3,3v1H9V7z M13,15.723V18h-2v-2.277c-0.595-0.346-1-0.984-1-1.723
-		c0-1.105,0.895-2,2-2s2,0.895,2,2C14,14.738,13.595,15.376,13,15.723z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-mail"><title>gridicons-mail</title> <g> <path d="M20,4H4C2.895,4,2,4.895,2,6v12c0,1.105,0.895,2,2,2h16c1.105,0,2-0.895,2-2V6C22,4.895,21.105,4,20,4z M20,8.236l-8,4.882
-		L4,8.236V6h16V8.236z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-mention"><title>gridicons-mention</title><g><path d="M12,2a10,10,0,0,0,0,20V20a8,8,0,1,1,8-8v.5a1.5,1.5,0,0,1-3,0V7H15V8A5,5,0,1,0,16,15a3.5,3.5,0,0,0,6-2.46V12A10,10,0,0,0,12,2Zm0,13a3,3,0,1,1,3-3A3,3,0,0,1,12,15Z"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-menu"><title>gridicons-menu</title> <g> <path d="M21,6v2H3V6H21z M3,18h18v-2H3V18z M3,13h18v-2H3V13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-menus"><title>gridicons-menus</title> <g> <path d="M9,19h10v-2H9V19z M9,13h6v-2H9V13z M9,5v2h12V5H9z M5,4.5C4.172,4.5,3.5,5.172,3.5,6S4.172,7.5,5,7.5S6.5,6.828,6.5,6
-		S5.828,4.5,5,4.5z M5,10.5c-0.828,0-1.5,0.672-1.5,1.5s0.672,1.5,1.5,1.5s1.5-0.672,1.5-1.5S5.828,10.5,5,10.5z M5,16.5
-		c-0.828,0-1.5,0.672-1.5,1.5s0.672,1.5,1.5,1.5s1.5-0.672,1.5-1.5S5.828,16.5,5,16.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-microphone"><title>gridicons-microphone</title><g><path d="M19,9v1a7,7,0,0,1-6,6.92V20h3v2H8V20h3V16.92A7,7,0,0,1,5,10V9H7v1a5,5,0,0,0,10,0V9Zm-7,4a3,3,0,0,0,3-3V5A3,3,0,0,0,9,5v5A3,3,0,0,0,12,13Z"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-minus-small"><title>gridicons-minus-small</title> <g> <rect x="6" y="11" width="12" height="2"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-minus"><title>gridicons-minus</title> <g> <rect x="3" y="11" width="18" height="2"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-money"><title>gridicons-money</title> <g> <path d="M2,5v14h20V5H2z M7,17c0-1.657-1.343-3-3-3v-4c1.657,0,3-1.343,3-3h10c0,1.657,1.343,3,3,3v4c-1.657,0-3,1.343-3,3H7z
-		 M12,9c1.1,0,2,1.3,2,3s-0.9,3-2,3s-2-1.3-2-3S10.9,9,12,9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-my-sites-horizon"><title>gridicons-my-sites-horizon</title> <g> <path d="M10.986,13.928l0.762-2.284l-1.324-3.629C9.966,7.988,9.532,7.934,9.532,7.934C9.074,7.907,9.127,7.207,9.586,7.233
-		c0,0,1.403,0.108,2.239,0.108c0.889,0,2.266-0.108,2.266-0.108c0.458-0.027,0.512,0.646,0.054,0.701c0,0-0.461,0.054-0.973,0.081
-		l2.006,5.966c-0.875-0.035-1.74-0.054-2.599-0.061l-0.429-1.177l-0.403,1.171C11.495,13.915,11.239,13.924,10.986,13.928z
-		 M3.83,14.321C3.62,13.583,3.5,12.806,3.5,12c0-1.232,0.264-2.402,0.736-3.459l2.036,5.578c0.849-0.059,1.69-0.103,2.526-0.137
-		L6.792,8.015c0.512-0.027,0.973-0.081,0.973-0.081C8.223,7.88,8.169,7.207,7.71,7.233c0,0-1.376,0.108-2.265,0.108
-		c-0.16,0-0.347-0.004-0.547-0.01C6.418,5.024,9.03,3.5,12,3.5c2.213,0,4.228,0.846,5.74,2.232c-0.036-0.002-0.072-0.007-0.11-0.007
-		c-0.835,0-1.427,0.727-1.427,1.509c0,0.701,0.404,1.293,0.835,1.994c0.323,0.566,0.701,1.293,0.701,2.344
-		c0,0.674-0.245,1.463-0.573,2.51c0.301,0.019,0.604,0.043,0.907,0.066l0.798-2.307c0.485-1.213,0.646-2.182,0.646-3.044
-		c0-0.313-0.021-0.603-0.057-0.874C20.122,9.133,20.5,10.522,20.5,12c0,0.807-0.128,1.581-0.339,2.32
-		c0.5,0.049,1.005,0.112,1.508,0.169C21.875,13.692,22,12.862,22,12c0-5.523-4.477-10-10-10S2,6.477,2,12
-		c0,0.862,0.125,1.692,0.331,2.49C2.831,14.433,3.333,14.37,3.83,14.321z M18.468,17.488c-1.792,2.184-4.35,3.013-6.468,3.013
-		c-1.876,0-4.551-0.698-6.463-3.013c-0.585,0.048-1.174,0.1-1.769,0.161C5.571,20.271,8.578,22,12,22
-		c3.422,0,6.429-1.729,8.232-4.351C19.639,17.587,19.052,17.536,18.468,17.488z M12,15.01c-3.715,0-7.368,0.266-10.958,0.733
-		c0.179,0.41,0.35,0.825,0.506,1.247c3.427-0.431,6.91-0.679,10.452-0.679s7.025,0.248,10.452,0.679
-		c0.156-0.422,0.327-0.836,0.506-1.246C19.368,15.277,15.715,15.01,12,15.01z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-my-sites"><title>gridicons-my-sites</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10s10-4.477,10-10C22,6.477,17.523,2,12,2z M3.5,12
-		c0-1.232,0.264-2.402,0.736-3.459L8.291,19.65C5.455,18.272,3.5,15.365,3.5,12z M12,20.501c-0.834,0-1.64-0.122-2.401-0.346
-		l2.551-7.411l2.613,7.158c0.017,0.042,0.038,0.081,0.061,0.117C13.939,20.33,12.99,20.501,12,20.501z M13.172,8.015
-		c0.512-0.027,0.973-0.081,0.973-0.081c0.458-0.054,0.404-0.727-0.054-0.701c0,0-1.377,0.108-2.266,0.108
-		c-0.835,0-2.239-0.108-2.239-0.108C9.127,7.207,9.074,7.907,9.532,7.934c0,0,0.434,0.054,0.892,0.081l1.324,3.629l-1.86,5.579
-		L6.792,8.015c0.512-0.027,0.973-0.081,0.973-0.081C8.223,7.88,8.168,7.207,7.71,7.233c0,0-1.376,0.108-2.265,0.108
-		c-0.16,0-0.347-0.004-0.547-0.01C6.418,5.024,9.03,3.5,12,3.5c2.213,0,4.228,0.846,5.74,2.232c-0.037-0.002-0.072-0.007-0.11-0.007
-		c-0.835,0-1.427,0.727-1.427,1.509c0,0.701,0.404,1.293,0.835,1.994c0.323,0.566,0.701,1.293,0.701,2.344
-		c0,0.727-0.28,1.572-0.647,2.748l-0.848,2.833L13.172,8.015z M16.273,19.347l2.596-7.506c0.485-1.213,0.646-2.182,0.646-3.045
-		c0-0.313-0.021-0.603-0.057-0.874C20.122,9.133,20.5,10.522,20.5,12C20.5,15.136,18.801,17.874,16.273,19.347z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-not-visible"><title>gridicons-not-visible</title> <g> <path d="M1,12c0,0,4.188-6,11-6c0.947,0,1.839,0.121,2.678,0.322L8.36,12.64C8.133,12.139,8,11.586,8,11
-		c0-0.937,0.335-1.787,0.875-2.469C6.483,9.343,4.661,10.916,3.621,12c0.678,0.707,1.695,1.621,2.98,2.398l-1.453,1.453
-		C2.497,14.13,1,12,1,12z M23,12c0,0-4.188,6-11,6c-0.946,0-1.836-0.124-2.676-0.323L5,22l-1.5-1.5l17-17L22,5l-3.147,3.147
-		C21.501,9.869,23,12,23,12z M20.385,12.006c-0.678-0.708-1.697-1.624-2.987-2.403L16,11c0,2.209-1.791,4-4,4l-0.947,0.947
-		C11.363,15.978,11.677,16,12,16C15.978,16,18.943,13.522,20.385,12.006z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-notice-outline"><title>gridicons-notice-outline</title> <g> <path d="M12,4c4.411,0,8,3.589,8,8s-3.589,8-8,8s-8-3.589-8-8S7.589,4,12,4 M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10
-		s10-4.477,10-10S17.523,2,12,2L12,2z M13,15h-2v2h2V15z M11,13h2l0.5-6h-3L11,13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-notice"><title>gridicons-notice</title> <g> <g> <path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10s10-4.477,10-10C22,6.477,17.523,2,12,2z M13,17h-2v-2h2V17z M13,13h-2
-			l-0.5-6h3L13,13z"/> </g> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-offline"><title>gridicons-offline</title><g><polygon points="10 3 18 3 14 9 18 9 6 21 10 12 6 12 10 3"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-pages"><title>gridicons-pages</title> <g> <path d="M16,8H8V6h8V8z M16,10H8v2h8V10z M20,4v12l-6,6H6c-1.105,0-2-0.895-2-2V4c0-1.105,0.895-2,2-2h12C19.105,2,20,2.895,20,4z
-		 M18,14V4H6v16h6v-4c0-1.105,0.895-2,2-2H18z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-pause"><title>gridicons-pause</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10s10-4.477,10-10S17.523,2,12,2z M11,16H9V8h2V16z M15,16h-2V8h2V16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-pencil"><title>gridicons-pencil</title> <g> <path d="M13,6l5,5l-9.507,9.507c-0.686-0.686-0.689-1.794-0.012-2.485l-0.003-0.003c-0.691,0.677-1.799,0.674-2.485-0.012
-		c-0.677-0.677-0.686-1.762-0.036-2.455l-0.008-0.008c-0.693,0.649-1.779,0.64-2.455-0.036L13,6z M20.586,5.586l-2.172-2.172
-		c-0.781-0.781-2.047-0.781-2.828,0L14,5l5,5l1.586-1.586C21.367,7.633,21.367,6.367,20.586,5.586z M3,18v3h3
-		C6,19.343,4.657,18,3,18z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-phone"><title>gridicons-phone</title> <g> <path d="M16,2H8C6.896,2,6,2.896,6,4v16c0,1.104,0.896,2,2,2h8c1.104,0,2-0.896,2-2V4C18,2.896,17.104,2,16,2z M13,21h-2v-1h2V21z
-		 M16,19H8V5h8V19z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-plugins"><title>gridicons-plugins</title> <g> <path d="M16,8V3c0-0.552-0.448-1-1-1s-1,0.448-1,1v5h-4V3c0-0.552-0.448-1-1-1S8,2.448,8,3v5H5v4c0,2.791,1.637,5.193,4,6.317V22h6
-		v-3.683c2.363-1.124,4-3.527,4-6.317V8H16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-plus-small"><title>gridicons-plus-small</title> <g> <polygon points="18,11 13,11 13,6 11,6 11,11 6,11 6,13 11,13 11,18 13,18 13,13 18,13 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-plus"><title>gridicons-plus</title><g><path d="M21,13H13v8H11V13H3V11h8V3h2v8h8v2Z"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-popout"><title>gridicons-popout</title> <path d="M6,7V5c0-1.105,0.895-2,2-2h11c1.105,0,2,0.895,2,2v14c0,1.105-0.895,2-2,2H8c-1.105,0-2-0.895-2-2v-2h2v2h11V5H8v2H6z
-	 M11.5,6.5l-1.414,1.414L13.172,11H3v2h10.172l-3.086,3.086L11.5,17.5L17,12L11.5,6.5z"/> </symbol><symbol viewBox="0 0 24 24" id="gridicons-posts"><title>gridicons-posts</title> <g> <path d="M16,19H3v-2h13V19z M21,9H3v2h18V9z M3,5v2h11V5H3z M17,5v2h4V5H17z M11,13v2h10v-2H11z M3,13v2h5v-2H3z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-print"><title>gridicons-print</title> <g> <path d="M9,16h6v2H9V16z M22,17h-3v3c0,1.105-0.895,2-2,2H7c-1.105,0-2-0.895-2-2v-3H2V9c0-1.105,0.895-2,2-2h1V5
-		c0-1.105,0.895-2,2-2h10c1.105,0,2,0.895,2,2v2h1c1.105,0,2,0.895,2,2V17z M7,7h10V5H7V7z M17,14H7v6h10V14z M20,10.5
-		C20,9.672,19.328,9,18.5,9S17,9.672,17,10.5s0.672,1.5,1.5,1.5S20,11.328,20,10.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-product-downloadable"><title>gridicons-product-downloadable</title> <g> <path d="M22,3H2v6h1v11c0,1.105,0.895,2,2,2h14c1.105,0,2-0.895,2-2V9h1V3z M4,5h16v2H4V5z M19,20H5V9h14V20z M13,10v5.17
-		l2.59-2.58L17,14l-5,5l-5-5l1.41-1.42L11,15.17V10H13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-product-external"><title>gridicons-product-external</title> <g> <path d="M22,3H2v6h1v11c0,1.105,0.895,2,2,2h14c1.105,0,2-0.895,2-2V9h1V3z M4,5h16v2H4V5z M19,20H5V9h14V20z M17,11v6h-2v-2.59
-		l-3.29,3.29l-1.41-1.41L13.59,13H11v-2H17z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-product-virtual"><title>gridicons-product-virtual</title> <g> <path d="M22,3H2v6h1v11c0,1.105,0.895,2,2,2h14c1.105,0,2-0.895,2-2V9h1V3z M4,5h16v2H4V5z M19,20H5V9h14V20z M7,16.45
-		c0-1.005,0.815-1.82,1.82-1.82h0.09c-0.335-1.589,0.681-3.148,2.27-3.483s3.148,0.681,3.483,2.27
-		c0.02,0.097,0.036,0.195,0.046,0.293l0,0c1.253-0.025,2.29,0.971,2.315,2.224c0.017,0.868-0.462,1.67-1.235,2.066H7.87
-		C7.329,17.671,6.999,17.083,7,16.45z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-product"><title>gridicons-product</title> <g> <path d="M22,3H2v6h1v11c0,1.105,0.895,2,2,2h14c1.105,0,2-0.895,2-2V9h1V3z M4,5h16v2H4V5z M19,20H5V9h14V20z M9,11h6
-		c0,1.105-0.895,2-2,2h-2C9.895,13,9,12.105,9,11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-quote"><title>gridicons-quote</title> <g> <path d="M11.192,15.757c0-0.88-0.23-1.618-0.69-2.217c-0.326-0.412-0.768-0.683-1.327-0.812c-0.55-0.128-1.07-0.137-1.54-0.028
-		c-0.16-0.95,0.1-1.956,0.76-3.022c0.66-1.065,1.515-1.867,2.558-2.403L9.372,5c-0.8,0.396-1.56,0.898-2.26,1.505
-		c-0.71,0.607-1.34,1.305-1.9,2.094s-0.98,1.68-1.25,2.69s-0.345,2.04-0.216,3.1c0.168,1.4,0.62,2.52,1.356,3.35
-		C5.837,18.58,6.754,19,7.85,19c0.965,0,1.766-0.29,2.4-0.878c0.628-0.576,0.94-1.365,0.94-2.368L11.192,15.757z M20.316,15.757
-		c0-0.88-0.23-1.618-0.69-2.217c-0.326-0.42-0.77-0.692-1.327-0.817c-0.56-0.124-1.073-0.13-1.54-0.022
-		c-0.16-0.94,0.09-1.95,0.752-3.02c0.66-1.06,1.513-1.86,2.556-2.4L18.49,5c-0.8,0.396-1.555,0.898-2.26,1.505
-		c-0.708,0.607-1.34,1.305-1.894,2.094c-0.556,0.79-0.97,1.68-1.24,2.69c-0.273,1.002-0.345,2.04-0.217,3.1
-		c0.166,1.4,0.616,2.52,1.35,3.35c0.733,0.834,1.647,1.252,2.743,1.252c0.967,0,1.768-0.29,2.402-0.877
-		c0.627-0.576,0.942-1.365,0.942-2.368L20.316,15.757z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-read-more"><title>gridicons-read-more</title> <path d="M3,5h18v4H3V5z M3,19h18v-4H3V19z M9,13h6v-2H9V13z M3,13h4v-2H3V13z M17,13h4v-2h-4V13z"/> </symbol><symbol viewBox="0 0 24 24" id="gridicons-reader-follow"><title>gridicons-reader-follow</title> <g> <path d="M23,16v2h-3v3h-2v-3h-3v-2h3v-3h2v3H23z M20,2v9h-4v3h-3v4H4c-1.1,0-2-0.9-2-2V2H20z M8,13v-1H4v1H8z M11,10H4v1h7V10z
-		 M11,8H4v1h7V8z M18,4H4v2h14V4z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-reader-following"><title>gridicons-reader-following</title> <g> <path d="M23,13.482L15.508,21L12,17.4l1.412-1.388l2.106,2.188l6.094-6.094L23,13.482z M15.545,15.344L20,10.889V2H2v14
-		c0,1.1,0.9,2,2,2h4.538l4.913-4.832L15.545,15.344z M8,13H4v-1h4V13z M11,11H4v-1h7V11z M11,9H4V8h7V9z M18,6H4V4h14V6z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-reader"><title>gridicons-reader</title> <g> <path d="M3,4v14c0,1.1,0.9,2,2,2h14c1.1,0,2-0.9,2-2V4H3z M10,15H5v-1h5V15z M12,13H5v-1h7V13z M12,11H5v-1h7V11z M19,15h-5v-5h5
-		V15z M19,8H5V6h14V8z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-reblog"><title>gridicons-reblog</title> <g> <path d="M22.086,9.914L20,7.828V18c0,1.105-0.895,2-2,2h-7v-2h7V7.828l-2.086,2.086L14.5,8.5L19,4l4.5,4.5L22.086,9.914z M6,16.172
-		V6h7V4H6C4.895,4,4,4.895,4,6v10.172l-2.086-2.086L0.5,15.5L5,20l4.5-4.5l-1.414-1.414L6,16.172z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-redo"><title>gridicons-redo</title> <g> <path d="M18,6v3.586l-3.657-3.657c-1.172-1.172-2.707-1.757-4.243-1.757S7.029,4.757,5.858,5.929c-2.343,2.343-2.343,6.142,0,8.485
-		l5.364,5.364l1.414-1.414L7.272,13c-1.56-1.56-1.56-4.097,0-5.657c0.755-0.755,1.76-1.172,2.828-1.172
-		c1.068,0,2.073,0.416,2.828,1.172L16.586,11H13v2h7V6H18z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-refresh"><title>gridicons-refresh</title> <g> <path d="M17.91,14c-0.478,2.833-2.943,5-5.91,5c-3.308,0-6-2.692-6-6s2.692-6,6-6h2.172l-2.086,2.086L13.5,10.5L18,6l-4.5-4.5
-		l-1.414,1.414L14.172,5H12c-4.418,0-8,3.582-8,8s3.582,8,8,8c4.079,0,7.438-3.055,7.931-7H17.91z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-refund"><title>gridicons-refund</title> <g> <path d="M13.91,2.91L11.83,5H14c4.418,0,8,3.582,8,8h-2c0-3.314-2.686-6-6-6h-2.17l2.09,2.09L12.5,10.5L8,6l1.41-1.41L12.5,1.5
-		L13.91,2.91z M2,12v10h16V12H2z M4,18.56v-3.11c0.601-0.349,1.101-0.849,1.45-1.45h9.1c0.349,0.601,0.849,1.101,1.45,1.45v3.11
-		c-0.593,0.349-1.085,0.845-1.43,1.44H5.45C5.1,19.403,4.6,18.906,4,18.56z M10,19c0.828,0,1.5-0.895,1.5-2s-0.672-2-1.5-2
-		s-1.5,0.895-1.5,2S9.172,19,10,19z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-reply"><title>gridicons-reply</title> <g> <path d="M14,8H6.828l2.586-2.586L8,4L3,9l5,5l1.414-1.414L6.828,10H14c2.206,0,4,1.794,4,4s-1.794,4-4,4h-2v2h2
-		c3.314,0,6-2.686,6-6S17.314,8,14,8z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-resize"><title>gridicons-resize</title><g><polygon points="13 4 13 6 16.59 6 6 16.59 6 13 4 13 4 20 11 20 11 18 7.41 18 18 7.41 18 11 20 11 20 4 13 4"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-rotate"><title>gridicons-rotate</title> <g> <path d="M18,14v6c0,1.105-0.895,2-2,2H6c-1.105,0-2-0.895-2-2v-6c0-1.105,0.895-2,2-2h10C17.105,12,18,12.895,18,14z M13.914,2.914
-		L11.828,5H14c4.418,0,8,3.582,8,8h-2c0-3.308-2.692-6-6-6h-2.172l2.086,2.086L12.5,10.5L8,6l1.414-1.414L12.5,1.5L13.914,2.914z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-scheduled"><title>gridicons-scheduled</title> <g> <path d="M10.498,18.001l-3.705-3.705l1.415-1.415l2.294,2.294l5.293-5.293l1.415,1.415L10.498,18.001z M21,6v13
-		c0,1.104-0.896,2-2,2H5c-1.104,0-2-0.896-2-2V6c0-1.104,0.896-2,2-2h1V2h2v2h8V2h2v2h1C20.104,4,21,4.896,21,6z M19,8H5v11h14V8z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-search"><title>gridicons-search</title> <g> <path d="M21,19l-5.154-5.154C16.574,12.742,17,11.421,17,10c0-3.866-3.134-7-7-7s-7,3.134-7,7c0,3.866,3.134,7,7,7
-		c1.421,0,2.742-0.426,3.846-1.154L19,21L21,19z M5,10c0-2.757,2.243-5,5-5s5,2.243,5,5s-2.243,5-5,5S5,12.757,5,10z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-share-ios"><title>gridicons-share-ios</title> <g> <path d="M17,8h2c1.105,0,2,0.895,2,2v9c0,1.105-0.895,2-2,2H5c-1.105,0-2-0.895-2-2v-9c0-1.105,0.895-2,2-2h2v2H5v9h14v-9h-2V8z
-		 M6.5,5.5l1.414,1.414L11,3.828V14h2V3.828l3.086,3.086L17.5,5.5L12,0L6.5,5.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-share"><title>gridicons-share</title> <g> <path d="M18,16c-0.788,0-1.499,0.31-2.034,0.807L8.91,12.7C8.96,12.47,9,12.24,9,12s-0.04-0.47-0.09-0.7l7.05-4.11
-		C16.5,7.69,17.21,8,18,8c1.66,0,3-1.34,3-3c0-1.66-1.34-3-3-3s-3,1.34-3,3c0,0.24,0.04,0.47,0.09,0.7L8.04,9.81
-		C7.5,9.31,6.79,9,6,9c-1.66,0-3,1.34-3,3c0,1.66,1.34,3,3,3c0.79,0,1.5-0.31,2.04-0.81l7.048,4.118C15.035,18.531,15,18.761,15,19
-		c0,1.657,1.343,3,3,3s3-1.343,3-3S19.657,16,18,16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-shipping"><title>gridicons-shipping</title> <g> <path d="M18,8h-2V7c0-1.105-0.895-2-2-2H4C2.895,5,2,5.895,2,7v10h2c0,1.657,1.343,3,3,3s3-1.343,3-3h4c0,1.657,1.343,3,3,3
-		s3-1.343,3-3h2v-5L18,8z M7,18.5c-0.828,0-1.5-0.672-1.5-1.5s0.672-1.5,1.5-1.5s1.5,0.672,1.5,1.5S7.828,18.5,7,18.5z M4,14V7h10v7
-		H4z M17,18.5c-0.828,0-1.5-0.672-1.5-1.5s0.672-1.5,1.5-1.5s1.5,0.672,1.5,1.5S17.828,18.5,17,18.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-sign-out"><title>gridicons-sign-out</title> <g> <path d="M16,17v2c0,1.105-0.895,2-2,2H5c-1.105,0-2-0.895-2-2V5c0-1.105,0.895-2,2-2h9c1.105,0,2,0.895,2,2v2h-2V5H5v14h9v-2H16z
-		 M18.5,6.5l-1.414,1.414L20.172,11H10v2h10.172l-3.086,3.086L18.5,17.5L24,12L18.5,6.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-spam"><title>gridicons-spam</title> <g> <path d="M17,2H7L2,7v10l5,5h10l5-5V7L17,2z M13,17h-2v-2h2V17z M13,13h-2l-0.5-6h3L13,13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-speaker"><title>gridicons-speaker</title> <g> <g> <path d="M19,8v3v3c1.7,0,3-1.3,3-3S20.7,8,19,8z"/> <g> <path d="M11,7H4C2.9,7,2,7.9,2,9v4c0,1.1,0.9,2,2,2h1v3c0,1.1,0.9,2,2,2h2v-3v-2h2l4,4h2V3h-2L11,7z"/> </g> </g> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-special-character"><title>gridicons-special-character</title> <g> <path d="M12.005,7.418c-1.237,0-2.191,0.376-2.861,1.128S8.14,10.358,8.14,11.725c0,1.388,0.226,2.514,0.677,3.378
-		c0.451,0.865,1.135,1.543,2.051,2.036V20H5v-2.666h3.119c-1.039-0.636-1.841-1.502-2.404-2.6c-0.564-1.097-0.846-2.322-0.846-3.676
-		c0-1.258,0.292-2.363,0.876-3.317C6.33,6.788,7.162,6.055,8.242,5.542s2.334-0.769,3.763-0.769c2.181,0,3.915,0.571,5.204,1.712
-		s1.933,2.673,1.933,4.594c0,1.354-0.283,2.57-0.852,3.65c-0.567,1.08-1.38,1.948-2.44,2.604H19V20h-5.908v-2.861
-		c0.95-0.492,1.651-1.179,2.102-2.061s0.677-2.006,0.677-3.374c0-1.36-0.337-2.415-1.01-3.164
-		C14.188,7.793,13.236,7.418,12.005,7.418z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-star-outline"><title>gridicons-star-outline</title> <g> <path d="M12,6.308l1.176,3.167l0.347,0.936l0.997,0.041l3.374,0.139l-2.647,2.092l-0.784,0.62l0.27,0.962l0.911,3.249l-2.814-1.871
-		L12,15.09l-0.83,0.552l-2.814,1.871l0.911-3.249l0.27-0.962l-0.784-0.62L6.105,10.59l3.374-0.139l0.997-0.041l0.347-0.936L12,6.308
-		 M12,2L9.418,8.953L2,9.257l5.822,4.602L5.82,21L12,16.891L18.18,21l-2.002-7.141L22,9.257l-7.418-0.305L12,2L12,2z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-star"><title>gridicons-star</title> <g> <polygon points="12,2 14.582,8.953 22,9.257 16.178,13.859 18.18,21 12,16.891 5.82,21 7.822,13.859 2,9.257 9.418,8.953 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-stats-alt"><title>gridicons-stats-alt</title> <g> <path d="M21,21H3v-2h18V21z M8,10H4v7h4V10z M14,3h-4v14h4V3z M20,6h-4v11h4V6z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-stats"><title>gridicons-stats</title> <g> <path d="M19,3H5C3.895,3,3,3.895,3,5v14c0,1.105,0.895,2,2,2h14c1.105,0,2-0.895,2-2V5C21,3.895,20.105,3,19,3z M19,19H5V5h14V19z
-		 M9,17H7v-5h2V17z M13,17h-2V7h2V17z M17,17h-2v-7h2V17z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-status"><title>gridicons-status</title> <g> <path d="M12,4c4.411,0,8,3.589,8,8s-3.589,8-8,8s-8-3.589-8-8S7.589,4,12,4 M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10
-		s10-4.477,10-10S17.523,2,12,2L12,2z M7.55,13c-0.019,0.166-0.05,0.329-0.05,0.5c0,2.485,2.015,4.5,4.5,4.5s4.5-2.015,4.5-4.5
-		c0-0.171-0.032-0.334-0.05-0.5H7.55z M10,10V8c0-0.552-0.448-1-1-1l0,0C8.448,7,8,7.448,8,8v2c0,0.552,0.448,1,1,1l0,0
-		C9.552,11,10,10.552,10,10z M16,10V8c0-0.552-0.448-1-1-1l0,0c-0.552,0-1,0.448-1,1v2c0,0.552,0.448,1,1,1l0,0
-		C15.552,11,16,10.552,16,10z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-strikethrough"><title>gridicons-strikethrough</title> <g> <path d="M14.348,12H21v2h-4.613c0.239,0.515,0.368,1.094,0.368,1.748c0,1.317-0.474,2.355-1.423,3.114
-		C14.385,19.621,13.066,20,11.376,20c-1.557,0-2.934-0.293-4.132-0.878v-2.874c0.985,0.439,1.818,0.749,2.5,0.928
-		c0.682,0.181,1.306,0.27,1.872,0.27c0.679,0,1.2-0.129,1.562-0.39c0.363-0.259,0.545-0.644,0.545-1.158
-		c0-0.285-0.08-0.54-0.24-0.763c-0.16-0.222-0.394-0.437-0.704-0.643c-0.18-0.12-0.482-0.287-0.88-0.491H3v-2h5.597H14.348z
-		 M10.82,10c-0.073-0.077-0.143-0.155-0.193-0.235c-0.126-0.202-0.189-0.441-0.189-0.713c0-0.439,0.156-0.795,0.469-1.068
-		c0.313-0.273,0.762-0.409,1.348-0.409c0.492,0,0.993,0.063,1.502,0.19c0.509,0.126,1.153,0.349,1.931,0.669l0.998-2.405
-		c-0.752-0.326-1.472-0.579-2.16-0.758C13.836,5.09,13.113,5,12.354,5C10.81,5,9.601,5.369,8.726,6.108
-		C7.852,6.846,7.414,7.861,7.414,9.152c0,0.302,0.036,0.58,0.088,0.848H10.82z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-sync"><title>gridicons-sync</title> <g> <path d="M23.5,13.5l-3.086,3.086L19,18l-4.5-4.5l1.414-1.414L18,14.172V12c0-3.308-2.692-6-6-6V4c4.418,0,8,3.582,8,8v2.172
-		l2.086-2.086L23.5,13.5z M6,12V9.828l2.086,2.086L9.5,10.5L5,6L3.586,7.414L0.5,10.5l1.414,1.414L4,9.828V12c0,4.418,3.582,8,8,8
-		v-2C8.692,18,6,15.308,6,12z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-tablet"><title>gridicons-tablet</title> <g> <path d="M18,2H6C4.896,2,4,2.896,4,4v16c0,1.104,0.896,2,2,2h12c1.104,0,2-0.896,2-2V4C20,2.896,19.104,2,18,2z M13,21h-2v-1h2V21z
-		 M18,19H6V5h12V19z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-tag"><title>gridicons-tag</title> <g> <path d="M20,2.007h-7.087c-0.53,0-1.039,0.211-1.414,0.586l-8.906,8.906c-0.781,0.781-0.781,2.047,0,2.828l7.086,7.086
-		c0.781,0.781,2.047,0.781,2.828,0l8.906-8.906C21.789,12.133,22,11.624,22,11.094V4.007C22,2.902,21.105,2.007,20,2.007z M17.007,9
-		c-1.105,0-2-0.895-2-2c0-1.105,0.895-2,2-2s2,0.895,2,2C19.007,8.105,18.112,9,17.007,9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-text-color"><title>gridicons-text-color</title> <g> <g> <path d="M3,19h18v3H3V19z"/> <path d="M15.82,17h3.424L14,3h-4L4.756,17h3.425l1.066-3.5h5.506L15.82,17z M13.868,11h-3.73l1.868-5.725L13.868,11z"/> </g> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-themes"><title>gridicons-themes</title> <g> <path d="M4,6L4,6C2.895,6,2,6.895,2,8v12c0,1.1,0.9,2,2,2h12c1.105,0,2-0.895,2-2v0H4V6z M20,2H8C6.895,2,6,2.895,6,4v12
-		c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V4C22,2.895,21.105,2,20,2z M15,16H8V9h7V16z M20,16h-3V9h3V16z M20,7H8V4h12V7z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-thumbs-up"><title>gridicons-thumbs-up</title> <g> <path d="M6.7,22H2v-9h2L6.7,22z M19.999,9H14V5c0-1.657-1.343-3-3-3h-1v4L7.1,9.625C6.388,10.515,6,11.621,6,12.76V14l2.1,7h8.337
-		c1.836,0,3.435-1.249,3.881-3.03l1.621-6.485C22.255,10.223,21.3,9,19.999,9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-time"><title>gridicons-time</title> <g> <path d="M12,4c4.411,0,8,3.589,8,8s-3.589,8-8,8s-8-3.589-8-8S7.589,4,12,4 M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10
-		s10-4.477,10-10S17.523,2,12,2L12,2z M15.8,15.4L13,11.667V7h-2v5.333l3.2,4.266L15.8,15.4z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-trash"><title>gridicons-trash</title> <g> <path d="M6.187,8h11.625l-0.695,11.125C17.051,20.179,16.177,21,15.121,21H8.879c-1.056,0-1.93-0.821-1.996-1.875L6.187,8z M19,5v2
-		H5V5h3V4c0-1.105,0.895-2,2-2h4c1.105,0,2,0.895,2,2v1H19z M10,5h4V4h-4V5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-trophy"><title>gridicons-trophy</title> <g> <path d="M18,5.062V3H6v2.062H2V8c0,2.525,1.889,4.598,4.324,4.932C7.024,14.99,8.809,16.542,11,16.91V18c0,1.105-0.895,2-2,2H8v2h1
-		h2h2h2h1v-2h-1c-1.105,0-2-0.895-2-2v-1.09c2.191-0.368,3.976-1.92,4.676-3.978C20.111,12.598,22,10.525,22,8V5.062H18z M4,8V7.062
-		h2v3.766C4.836,10.416,4,9.304,4,8z M20,8c0,1.304-0.836,2.416-2,2.829V7.062h2V8z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-types"><title>gridicons-types</title> <g> <path d="M22,17c0,2.761-2.239,5-5,5s-5-2.239-5-5s2.239-5,5-5S22,14.239,22,17z M6.5,6.5h3.8L7,1L1,11h5.5V6.5z M16,10.585V8H8v8
-		h2.585C11.018,13.217,13.217,11.018,16,10.585z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-underline"><title>gridicons-underline</title> <g> <path d="M4,19v2h16v-2H4z M18,3v8c0,3.314-2.686,6-6,6s-6-2.686-6-6V3h3v8c0,1.654,1.346,3,3,3c1.654,0,3-1.346,3-3V3H18z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-undo"><title>gridicons-undo</title> <g> <path d="M18.142,5.929c-1.172-1.172-2.707-1.757-4.243-1.757s-3.071,0.586-4.243,1.757L6,9.586V6H4v7h7v-2H7.414l3.657-3.657
-		c0.755-0.755,1.76-1.172,2.828-1.172c1.068,0,2.073,0.416,2.828,1.172c1.56,1.56,1.56,4.097,0,5.657l-5.364,5.364l1.414,1.414
-		l5.364-5.364C20.485,12.071,20.485,8.272,18.142,5.929z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-user-add"><title>gridicons-user-add</title><g><g data-name="Artwork"><g data-name="Artwork"><circle cx="15" cy="8" r="4"/><path d="M15,20s8,0,8-2c0-2.4-3.9-5-8-5s-8,2.6-8,5C7,20,15,20,15,20Z"/></g><path d="M6,10V7H4v3H1v2H4v3H6V12H9V10Z"/></g></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-user-circle"><title>gridicons-user-circle</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10s10-4.477,10-10C22,6.477,17.523,2,12,2z M12,20.5
-		c-4.694,0-8.5-3.806-8.5-8.5c0-4.694,3.806-8.5,8.5-8.5s8.5,3.806,8.5,8.5C20.5,16.694,16.694,20.5,12,20.5z M12,12.5
-		c-3.038,0-5.5,1.728-5.5,3.5s2.462,3.5,5.5,3.5s5.5-1.728,5.5-3.5S15.038,12.5,12,12.5z M12,12c1.657,0,3-1.343,3-3
-		c0-1.657-1.343-3-3-3S9,7.343,9,9C9,10.657,10.343,12,12,12z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-user"><title>gridicons-user</title> <g> <path d="M12,4c2.209,0,4,1.791,4,4s-1.791,4-4,4c-2.209,0-4-1.791-4-4S9.791,4,12,4z M12,20c0,0,8,0,8-2c0-2.4-3.9-5-8-5
-		s-8,2.6-8,5C4,20,12,20,12,20z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-video-camera"><title>gridicons-video-camera</title> <g> <path d="M17,9V7c0-1.105-0.895-2-2-2H4C2.895,5,2,5.895,2,7v10c0,1.105,0.895,2,2,2h11c1.105,0,2-0.895,2-2v-2l5,4V5L17,9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-video"><title>gridicons-video</title> <g> <path d="M20,4v2h-2V4H6v2H4V4C2.895,4,2,4.895,2,6v12c0,1.105,0.895,2,2,2v-2h2v2h12v-2h2v2c1.105,0,2-0.895,2-2V6
-		C22,4.895,21.105,4,20,4z M6,16H4v-3h2V16z M6,11H4V8h2V11z M10,15V9l4.5,3L10,15z M20,16h-2v-3h2V16z M20,11h-2V8h2V11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-visible"><title>gridicons-visible</title> <g> <path d="M12,6C5.188,6,1,12,1,12s4.188,6,11,6s11-6,11-6S18.812,6,12,6z M12,16c-3.943,0-6.926-2.484-8.379-4
-		c1.04-1.085,2.862-2.657,5.254-3.469C8.335,9.213,8,10.063,8,11c0,2.209,1.791,4,4,4s4-1.791,4-4c0-0.937-0.335-1.787-0.875-2.469
-		c2.393,0.812,4.216,2.385,5.254,3.469C18.924,13.518,15.942,16,12,16z"/> </g>  </symbol></svg>
-
 <div class="icons">
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-add-image">
-		<use xlink:href="#gridicons-add-image" />
+		<use xlink:href="gridicons.svg#gridicons-add-image" />
 		</svg>
 		<p>gridicons-add-image</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-add-outline">
-		<use xlink:href="#gridicons-add-outline" />
+		<use xlink:href="gridicons.svg#gridicons-add-outline" />
 		</svg>
 		<p>gridicons-add-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-add">
-		<use xlink:href="#gridicons-add" />
+		<use xlink:href="gridicons.svg#gridicons-add" />
 		</svg>
 		<p>gridicons-add</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-center">
-		<use xlink:href="#gridicons-align-center" />
+		<use xlink:href="gridicons.svg#gridicons-align-center" />
 		</svg>
 		<p>gridicons-align-center</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-image-center">
-		<use xlink:href="#gridicons-align-image-center" />
+		<use xlink:href="gridicons.svg#gridicons-align-image-center" />
 		</svg>
 		<p>gridicons-align-image-center</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-image-left">
-		<use xlink:href="#gridicons-align-image-left" />
+		<use xlink:href="gridicons.svg#gridicons-align-image-left" />
 		</svg>
 		<p>gridicons-align-image-left</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-image-none">
-		<use xlink:href="#gridicons-align-image-none" />
+		<use xlink:href="gridicons.svg#gridicons-align-image-none" />
 		</svg>
 		<p>gridicons-align-image-none</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-image-right">
-		<use xlink:href="#gridicons-align-image-right" />
+		<use xlink:href="gridicons.svg#gridicons-align-image-right" />
 		</svg>
 		<p>gridicons-align-image-right</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-justify">
-		<use xlink:href="#gridicons-align-justify" />
+		<use xlink:href="gridicons.svg#gridicons-align-justify" />
 		</svg>
 		<p>gridicons-align-justify</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-left">
-		<use xlink:href="#gridicons-align-left" />
+		<use xlink:href="gridicons.svg#gridicons-align-left" />
 		</svg>
 		<p>gridicons-align-left</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-right">
-		<use xlink:href="#gridicons-align-right" />
+		<use xlink:href="gridicons.svg#gridicons-align-right" />
 		</svg>
 		<p>gridicons-align-right</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-arrow-down">
-		<use xlink:href="#gridicons-arrow-down" />
+		<use xlink:href="gridicons.svg#gridicons-arrow-down" />
 		</svg>
 		<p>gridicons-arrow-down</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-arrow-left">
-		<use xlink:href="#gridicons-arrow-left" />
+		<use xlink:href="gridicons.svg#gridicons-arrow-left" />
 		</svg>
 		<p>gridicons-arrow-left</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-arrow-right">
-		<use xlink:href="#gridicons-arrow-right" />
+		<use xlink:href="gridicons.svg#gridicons-arrow-right" />
 		</svg>
 		<p>gridicons-arrow-right</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-arrow-up">
-		<use xlink:href="#gridicons-arrow-up" />
+		<use xlink:href="gridicons.svg#gridicons-arrow-up" />
 		</svg>
 		<p>gridicons-arrow-up</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-aside">
-		<use xlink:href="#gridicons-aside" />
+		<use xlink:href="gridicons.svg#gridicons-aside" />
 		</svg>
 		<p>gridicons-aside</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-attachment">
-		<use xlink:href="#gridicons-attachment" />
+		<use xlink:href="gridicons.svg#gridicons-attachment" />
 		</svg>
 		<p>gridicons-attachment</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-audio">
-		<use xlink:href="#gridicons-audio" />
+		<use xlink:href="gridicons.svg#gridicons-audio" />
 		</svg>
 		<p>gridicons-audio</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-bell">
-		<use xlink:href="#gridicons-bell" />
+		<use xlink:href="gridicons.svg#gridicons-bell" />
 		</svg>
 		<p>gridicons-bell</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-block">
-		<use xlink:href="#gridicons-block" />
+		<use xlink:href="gridicons.svg#gridicons-block" />
 		</svg>
 		<p>gridicons-block</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-bold">
-		<use xlink:href="#gridicons-bold" />
+		<use xlink:href="gridicons.svg#gridicons-bold" />
 		</svg>
 		<p>gridicons-bold</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-book">
-		<use xlink:href="#gridicons-book" />
+		<use xlink:href="gridicons.svg#gridicons-book" />
 		</svg>
 		<p>gridicons-book</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-bookmark-outline">
-		<use xlink:href="#gridicons-bookmark-outline" />
+		<use xlink:href="gridicons.svg#gridicons-bookmark-outline" />
 		</svg>
 		<p>gridicons-bookmark-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-bookmark">
-		<use xlink:href="#gridicons-bookmark" />
+		<use xlink:href="gridicons.svg#gridicons-bookmark" />
 		</svg>
 		<p>gridicons-bookmark</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-briefcase">
-		<use xlink:href="#gridicons-briefcase" />
+		<use xlink:href="gridicons.svg#gridicons-briefcase" />
 		</svg>
 		<p>gridicons-briefcase</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-calendar">
-		<use xlink:href="#gridicons-calendar" />
+		<use xlink:href="gridicons.svg#gridicons-calendar" />
 		</svg>
 		<p>gridicons-calendar</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-camera">
-		<use xlink:href="#gridicons-camera" />
+		<use xlink:href="gridicons.svg#gridicons-camera" />
 		</svg>
 		<p>gridicons-camera</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-caption">
-		<use xlink:href="#gridicons-caption" />
+		<use xlink:href="gridicons.svg#gridicons-caption" />
 		</svg>
 		<p>gridicons-caption</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cart">
-		<use xlink:href="#gridicons-cart" />
+		<use xlink:href="gridicons.svg#gridicons-cart" />
 		</svg>
 		<p>gridicons-cart</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-chat">
-		<use xlink:href="#gridicons-chat" />
+		<use xlink:href="gridicons.svg#gridicons-chat" />
 		</svg>
 		<p>gridicons-chat</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-checkmark-circle">
-		<use xlink:href="#gridicons-checkmark-circle" />
+		<use xlink:href="gridicons.svg#gridicons-checkmark-circle" />
 		</svg>
 		<p>gridicons-checkmark-circle</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-checkmark">
-		<use xlink:href="#gridicons-checkmark" />
+		<use xlink:href="gridicons.svg#gridicons-checkmark" />
 		</svg>
 		<p>gridicons-checkmark</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-chevron-down">
-		<use xlink:href="#gridicons-chevron-down" />
+		<use xlink:href="gridicons.svg#gridicons-chevron-down" />
 		</svg>
 		<p>gridicons-chevron-down</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-chevron-left">
-		<use xlink:href="#gridicons-chevron-left" />
+		<use xlink:href="gridicons.svg#gridicons-chevron-left" />
 		</svg>
 		<p>gridicons-chevron-left</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-chevron-right">
-		<use xlink:href="#gridicons-chevron-right" />
+		<use xlink:href="gridicons.svg#gridicons-chevron-right" />
 		</svg>
 		<p>gridicons-chevron-right</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-chevron-up">
-		<use xlink:href="#gridicons-chevron-up" />
+		<use xlink:href="gridicons.svg#gridicons-chevron-up" />
 		</svg>
 		<p>gridicons-chevron-up</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-clear-formatting">
-		<use xlink:href="#gridicons-clear-formatting" />
+		<use xlink:href="gridicons.svg#gridicons-clear-formatting" />
 		</svg>
 		<p>gridicons-clear-formatting</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-clipboard">
-		<use xlink:href="#gridicons-clipboard" />
+		<use xlink:href="gridicons.svg#gridicons-clipboard" />
 		</svg>
 		<p>gridicons-clipboard</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cloud-download">
-		<use xlink:href="#gridicons-cloud-download" />
+		<use xlink:href="gridicons.svg#gridicons-cloud-download" />
 		</svg>
 		<p>gridicons-cloud-download</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cloud-outline">
-		<use xlink:href="#gridicons-cloud-outline" />
+		<use xlink:href="gridicons.svg#gridicons-cloud-outline" />
 		</svg>
 		<p>gridicons-cloud-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cloud-upload">
-		<use xlink:href="#gridicons-cloud-upload" />
+		<use xlink:href="gridicons.svg#gridicons-cloud-upload" />
 		</svg>
 		<p>gridicons-cloud-upload</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cloud">
-		<use xlink:href="#gridicons-cloud" />
+		<use xlink:href="gridicons.svg#gridicons-cloud" />
 		</svg>
 		<p>gridicons-cloud</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-code">
-		<use xlink:href="#gridicons-code" />
+		<use xlink:href="gridicons.svg#gridicons-code" />
 		</svg>
 		<p>gridicons-code</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cog">
-		<use xlink:href="#gridicons-cog" />
+		<use xlink:href="gridicons.svg#gridicons-cog" />
 		</svg>
 		<p>gridicons-cog</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-comment">
-		<use xlink:href="#gridicons-comment" />
+		<use xlink:href="gridicons.svg#gridicons-comment" />
 		</svg>
 		<p>gridicons-comment</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-computer">
-		<use xlink:href="#gridicons-computer" />
+		<use xlink:href="gridicons.svg#gridicons-computer" />
 		</svg>
 		<p>gridicons-computer</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-coupon">
-		<use xlink:href="#gridicons-coupon" />
+		<use xlink:href="gridicons.svg#gridicons-coupon" />
 		</svg>
 		<p>gridicons-coupon</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-create">
-		<use xlink:href="#gridicons-create" />
+		<use xlink:href="gridicons.svg#gridicons-create" />
 		</svg>
 		<p>gridicons-create</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-credit-card">
-		<use xlink:href="#gridicons-credit-card" />
+		<use xlink:href="gridicons.svg#gridicons-credit-card" />
 		</svg>
 		<p>gridicons-credit-card</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-crop">
-		<use xlink:href="#gridicons-crop" />
+		<use xlink:href="gridicons.svg#gridicons-crop" />
 		</svg>
 		<p>gridicons-crop</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cross-circle">
-		<use xlink:href="#gridicons-cross-circle" />
+		<use xlink:href="gridicons.svg#gridicons-cross-circle" />
 		</svg>
 		<p>gridicons-cross-circle</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cross-small">
-		<use xlink:href="#gridicons-cross-small" />
+		<use xlink:href="gridicons.svg#gridicons-cross-small" />
 		</svg>
 		<p>gridicons-cross-small</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cross">
-		<use xlink:href="#gridicons-cross" />
+		<use xlink:href="gridicons.svg#gridicons-cross" />
 		</svg>
 		<p>gridicons-cross</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-custom-post-type">
-		<use xlink:href="#gridicons-custom-post-type" />
+		<use xlink:href="gridicons.svg#gridicons-custom-post-type" />
 		</svg>
 		<p>gridicons-custom-post-type</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-customize">
-		<use xlink:href="#gridicons-customize" />
+		<use xlink:href="gridicons.svg#gridicons-customize" />
 		</svg>
 		<p>gridicons-customize</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-domains">
-		<use xlink:href="#gridicons-domains" />
+		<use xlink:href="gridicons.svg#gridicons-domains" />
 		</svg>
 		<p>gridicons-domains</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-dropdown">
-		<use xlink:href="#gridicons-dropdown" />
+		<use xlink:href="gridicons.svg#gridicons-dropdown" />
 		</svg>
 		<p>gridicons-dropdown</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-ellipsis-circle">
-		<use xlink:href="#gridicons-ellipsis-circle" />
+		<use xlink:href="gridicons.svg#gridicons-ellipsis-circle" />
 		</svg>
 		<p>gridicons-ellipsis-circle</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-ellipsis">
-		<use xlink:href="#gridicons-ellipsis" />
+		<use xlink:href="gridicons.svg#gridicons-ellipsis" />
 		</svg>
 		<p>gridicons-ellipsis</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-external">
-		<use xlink:href="#gridicons-external" />
+		<use xlink:href="gridicons.svg#gridicons-external" />
 		</svg>
 		<p>gridicons-external</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-filter">
-		<use xlink:href="#gridicons-filter" />
+		<use xlink:href="gridicons.svg#gridicons-filter" />
 		</svg>
 		<p>gridicons-filter</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-flag">
-		<use xlink:href="#gridicons-flag" />
+		<use xlink:href="gridicons.svg#gridicons-flag" />
 		</svg>
 		<p>gridicons-flag</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-flip-horizontal">
-		<use xlink:href="#gridicons-flip-horizontal" />
+		<use xlink:href="gridicons.svg#gridicons-flip-horizontal" />
 		</svg>
 		<p>gridicons-flip-horizontal</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-flip-vertical">
-		<use xlink:href="#gridicons-flip-vertical" />
+		<use xlink:href="gridicons.svg#gridicons-flip-vertical" />
 		</svg>
 		<p>gridicons-flip-vertical</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-folder-multiple">
-		<use xlink:href="#gridicons-folder-multiple" />
+		<use xlink:href="gridicons.svg#gridicons-folder-multiple" />
 		</svg>
 		<p>gridicons-folder-multiple</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-folder">
-		<use xlink:href="#gridicons-folder" />
+		<use xlink:href="gridicons.svg#gridicons-folder" />
 		</svg>
 		<p>gridicons-folder</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-fullscreen-exit">
-		<use xlink:href="#gridicons-fullscreen-exit" />
+		<use xlink:href="gridicons.svg#gridicons-fullscreen-exit" />
 		</svg>
 		<p>gridicons-fullscreen-exit</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-fullscreen">
-		<use xlink:href="#gridicons-fullscreen" />
+		<use xlink:href="gridicons.svg#gridicons-fullscreen" />
 		</svg>
 		<p>gridicons-fullscreen</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-globe">
-		<use xlink:href="#gridicons-globe" />
+		<use xlink:href="gridicons.svg#gridicons-globe" />
 		</svg>
 		<p>gridicons-globe</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-grid">
-		<use xlink:href="#gridicons-grid" />
+		<use xlink:href="gridicons.svg#gridicons-grid" />
 		</svg>
 		<p>gridicons-grid</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-heading">
-		<use xlink:href="#gridicons-heading" />
+		<use xlink:href="gridicons.svg#gridicons-heading" />
 		</svg>
 		<p>gridicons-heading</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-heart-outline">
-		<use xlink:href="#gridicons-heart-outline" />
+		<use xlink:href="gridicons.svg#gridicons-heart-outline" />
 		</svg>
 		<p>gridicons-heart-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-heart">
-		<use xlink:href="#gridicons-heart" />
+		<use xlink:href="gridicons.svg#gridicons-heart" />
 		</svg>
 		<p>gridicons-heart</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-help-outline">
-		<use xlink:href="#gridicons-help-outline" />
+		<use xlink:href="gridicons.svg#gridicons-help-outline" />
 		</svg>
 		<p>gridicons-help-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-help">
-		<use xlink:href="#gridicons-help" />
+		<use xlink:href="gridicons.svg#gridicons-help" />
 		</svg>
 		<p>gridicons-help</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-history">
-		<use xlink:href="#gridicons-history" />
+		<use xlink:href="gridicons.svg#gridicons-history" />
 		</svg>
 		<p>gridicons-history</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-house">
-		<use xlink:href="#gridicons-house" />
+		<use xlink:href="gridicons.svg#gridicons-house" />
 		</svg>
 		<p>gridicons-house</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-image-multiple">
-		<use xlink:href="#gridicons-image-multiple" />
+		<use xlink:href="gridicons.svg#gridicons-image-multiple" />
 		</svg>
 		<p>gridicons-image-multiple</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-image">
-		<use xlink:href="#gridicons-image" />
+		<use xlink:href="gridicons.svg#gridicons-image" />
 		</svg>
 		<p>gridicons-image</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-indent-left">
-		<use xlink:href="#gridicons-indent-left" />
+		<use xlink:href="gridicons.svg#gridicons-indent-left" />
 		</svg>
 		<p>gridicons-indent-left</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-indent-right">
-		<use xlink:href="#gridicons-indent-right" />
+		<use xlink:href="gridicons.svg#gridicons-indent-right" />
 		</svg>
 		<p>gridicons-indent-right</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-info-outline">
-		<use xlink:href="#gridicons-info-outline" />
+		<use xlink:href="gridicons.svg#gridicons-info-outline" />
 		</svg>
 		<p>gridicons-info-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-info">
-		<use xlink:href="#gridicons-info" />
+		<use xlink:href="gridicons.svg#gridicons-info" />
 		</svg>
 		<p>gridicons-info</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-ink">
-		<use xlink:href="#gridicons-ink" />
+		<use xlink:href="gridicons.svg#gridicons-ink" />
 		</svg>
 		<p>gridicons-ink</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-institution">
-		<use xlink:href="#gridicons-institution" />
+		<use xlink:href="gridicons.svg#gridicons-institution" />
 		</svg>
 		<p>gridicons-institution</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-italic">
-		<use xlink:href="#gridicons-italic" />
+		<use xlink:href="gridicons.svg#gridicons-italic" />
 		</svg>
 		<p>gridicons-italic</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-layout-blocks">
-		<use xlink:href="#gridicons-layout-blocks" />
+		<use xlink:href="gridicons.svg#gridicons-layout-blocks" />
 		</svg>
 		<p>gridicons-layout-blocks</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-layout">
-		<use xlink:href="#gridicons-layout" />
+		<use xlink:href="gridicons.svg#gridicons-layout" />
 		</svg>
 		<p>gridicons-layout</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-link-break">
-		<use xlink:href="#gridicons-link-break" />
+		<use xlink:href="gridicons.svg#gridicons-link-break" />
 		</svg>
 		<p>gridicons-link-break</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-link">
-		<use xlink:href="#gridicons-link" />
+		<use xlink:href="gridicons.svg#gridicons-link" />
 		</svg>
 		<p>gridicons-link</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-list-checkmark">
-		<use xlink:href="#gridicons-list-checkmark" />
+		<use xlink:href="gridicons.svg#gridicons-list-checkmark" />
 		</svg>
 		<p>gridicons-list-checkmark</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-list-ordered">
-		<use xlink:href="#gridicons-list-ordered" />
+		<use xlink:href="gridicons.svg#gridicons-list-ordered" />
 		</svg>
 		<p>gridicons-list-ordered</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-list-unordered">
-		<use xlink:href="#gridicons-list-unordered" />
+		<use xlink:href="gridicons.svg#gridicons-list-unordered" />
 		</svg>
 		<p>gridicons-list-unordered</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-location">
-		<use xlink:href="#gridicons-location" />
+		<use xlink:href="gridicons.svg#gridicons-location" />
 		</svg>
 		<p>gridicons-location</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-lock">
-		<use xlink:href="#gridicons-lock" />
+		<use xlink:href="gridicons.svg#gridicons-lock" />
 		</svg>
 		<p>gridicons-lock</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-mail">
-		<use xlink:href="#gridicons-mail" />
+		<use xlink:href="gridicons.svg#gridicons-mail" />
 		</svg>
 		<p>gridicons-mail</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-mention">
-		<use xlink:href="#gridicons-mention" />
+		<use xlink:href="gridicons.svg#gridicons-mention" />
 		</svg>
 		<p>gridicons-mention</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-menu">
-		<use xlink:href="#gridicons-menu" />
+		<use xlink:href="gridicons.svg#gridicons-menu" />
 		</svg>
 		<p>gridicons-menu</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-menus">
-		<use xlink:href="#gridicons-menus" />
+		<use xlink:href="gridicons.svg#gridicons-menus" />
 		</svg>
 		<p>gridicons-menus</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-microphone">
-		<use xlink:href="#gridicons-microphone" />
+		<use xlink:href="gridicons.svg#gridicons-microphone" />
 		</svg>
 		<p>gridicons-microphone</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-minus-small">
-		<use xlink:href="#gridicons-minus-small" />
+		<use xlink:href="gridicons.svg#gridicons-minus-small" />
 		</svg>
 		<p>gridicons-minus-small</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-minus">
-		<use xlink:href="#gridicons-minus" />
+		<use xlink:href="gridicons.svg#gridicons-minus" />
 		</svg>
 		<p>gridicons-minus</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-money">
-		<use xlink:href="#gridicons-money" />
+		<use xlink:href="gridicons.svg#gridicons-money" />
 		</svg>
 		<p>gridicons-money</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-my-sites-horizon">
-		<use xlink:href="#gridicons-my-sites-horizon" />
+		<use xlink:href="gridicons.svg#gridicons-my-sites-horizon" />
 		</svg>
 		<p>gridicons-my-sites-horizon</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-my-sites">
-		<use xlink:href="#gridicons-my-sites" />
+		<use xlink:href="gridicons.svg#gridicons-my-sites" />
 		</svg>
 		<p>gridicons-my-sites</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-not-visible">
-		<use xlink:href="#gridicons-not-visible" />
+		<use xlink:href="gridicons.svg#gridicons-not-visible" />
 		</svg>
 		<p>gridicons-not-visible</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-notice-outline">
-		<use xlink:href="#gridicons-notice-outline" />
+		<use xlink:href="gridicons.svg#gridicons-notice-outline" />
 		</svg>
 		<p>gridicons-notice-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-notice">
-		<use xlink:href="#gridicons-notice" />
+		<use xlink:href="gridicons.svg#gridicons-notice" />
 		</svg>
 		<p>gridicons-notice</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-offline">
-		<use xlink:href="#gridicons-offline" />
+		<use xlink:href="gridicons.svg#gridicons-offline" />
 		</svg>
 		<p>gridicons-offline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-pages">
-		<use xlink:href="#gridicons-pages" />
+		<use xlink:href="gridicons.svg#gridicons-pages" />
 		</svg>
 		<p>gridicons-pages</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-pause">
-		<use xlink:href="#gridicons-pause" />
+		<use xlink:href="gridicons.svg#gridicons-pause" />
 		</svg>
 		<p>gridicons-pause</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-pencil">
-		<use xlink:href="#gridicons-pencil" />
+		<use xlink:href="gridicons.svg#gridicons-pencil" />
 		</svg>
 		<p>gridicons-pencil</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-phone">
-		<use xlink:href="#gridicons-phone" />
+		<use xlink:href="gridicons.svg#gridicons-phone" />
 		</svg>
 		<p>gridicons-phone</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-plugins">
-		<use xlink:href="#gridicons-plugins" />
+		<use xlink:href="gridicons.svg#gridicons-plugins" />
 		</svg>
 		<p>gridicons-plugins</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-plus-small">
-		<use xlink:href="#gridicons-plus-small" />
+		<use xlink:href="gridicons.svg#gridicons-plus-small" />
 		</svg>
 		<p>gridicons-plus-small</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-plus">
-		<use xlink:href="#gridicons-plus" />
+		<use xlink:href="gridicons.svg#gridicons-plus" />
 		</svg>
 		<p>gridicons-plus</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-popout">
-		<use xlink:href="#gridicons-popout" />
+		<use xlink:href="gridicons.svg#gridicons-popout" />
 		</svg>
 		<p>gridicons-popout</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-posts">
-		<use xlink:href="#gridicons-posts" />
+		<use xlink:href="gridicons.svg#gridicons-posts" />
 		</svg>
 		<p>gridicons-posts</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-print">
-		<use xlink:href="#gridicons-print" />
+		<use xlink:href="gridicons.svg#gridicons-print" />
 		</svg>
 		<p>gridicons-print</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-product-downloadable">
-		<use xlink:href="#gridicons-product-downloadable" />
+		<use xlink:href="gridicons.svg#gridicons-product-downloadable" />
 		</svg>
 		<p>gridicons-product-downloadable</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-product-external">
-		<use xlink:href="#gridicons-product-external" />
+		<use xlink:href="gridicons.svg#gridicons-product-external" />
 		</svg>
 		<p>gridicons-product-external</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-product-virtual">
-		<use xlink:href="#gridicons-product-virtual" />
+		<use xlink:href="gridicons.svg#gridicons-product-virtual" />
 		</svg>
 		<p>gridicons-product-virtual</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-product">
-		<use xlink:href="#gridicons-product" />
+		<use xlink:href="gridicons.svg#gridicons-product" />
 		</svg>
 		<p>gridicons-product</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-quote">
-		<use xlink:href="#gridicons-quote" />
+		<use xlink:href="gridicons.svg#gridicons-quote" />
 		</svg>
 		<p>gridicons-quote</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-read-more">
-		<use xlink:href="#gridicons-read-more" />
+		<use xlink:href="gridicons.svg#gridicons-read-more" />
 		</svg>
 		<p>gridicons-read-more</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-reader-follow">
-		<use xlink:href="#gridicons-reader-follow" />
+		<use xlink:href="gridicons.svg#gridicons-reader-follow" />
 		</svg>
 		<p>gridicons-reader-follow</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-reader-following">
-		<use xlink:href="#gridicons-reader-following" />
+		<use xlink:href="gridicons.svg#gridicons-reader-following" />
 		</svg>
 		<p>gridicons-reader-following</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-reader">
-		<use xlink:href="#gridicons-reader" />
+		<use xlink:href="gridicons.svg#gridicons-reader" />
 		</svg>
 		<p>gridicons-reader</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-reblog">
-		<use xlink:href="#gridicons-reblog" />
+		<use xlink:href="gridicons.svg#gridicons-reblog" />
 		</svg>
 		<p>gridicons-reblog</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-redo">
-		<use xlink:href="#gridicons-redo" />
+		<use xlink:href="gridicons.svg#gridicons-redo" />
 		</svg>
 		<p>gridicons-redo</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-refresh">
-		<use xlink:href="#gridicons-refresh" />
+		<use xlink:href="gridicons.svg#gridicons-refresh" />
 		</svg>
 		<p>gridicons-refresh</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-refund">
-		<use xlink:href="#gridicons-refund" />
+		<use xlink:href="gridicons.svg#gridicons-refund" />
 		</svg>
 		<p>gridicons-refund</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-reply">
-		<use xlink:href="#gridicons-reply" />
+		<use xlink:href="gridicons.svg#gridicons-reply" />
 		</svg>
 		<p>gridicons-reply</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-resize">
-		<use xlink:href="#gridicons-resize" />
+		<use xlink:href="gridicons.svg#gridicons-resize" />
 		</svg>
 		<p>gridicons-resize</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-rotate">
-		<use xlink:href="#gridicons-rotate" />
+		<use xlink:href="gridicons.svg#gridicons-rotate" />
 		</svg>
 		<p>gridicons-rotate</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-scheduled">
-		<use xlink:href="#gridicons-scheduled" />
+		<use xlink:href="gridicons.svg#gridicons-scheduled" />
 		</svg>
 		<p>gridicons-scheduled</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-search">
-		<use xlink:href="#gridicons-search" />
+		<use xlink:href="gridicons.svg#gridicons-search" />
 		</svg>
 		<p>gridicons-search</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-share-ios">
-		<use xlink:href="#gridicons-share-ios" />
+		<use xlink:href="gridicons.svg#gridicons-share-ios" />
 		</svg>
 		<p>gridicons-share-ios</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-share">
-		<use xlink:href="#gridicons-share" />
+		<use xlink:href="gridicons.svg#gridicons-share" />
 		</svg>
 		<p>gridicons-share</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-shipping">
-		<use xlink:href="#gridicons-shipping" />
+		<use xlink:href="gridicons.svg#gridicons-shipping" />
 		</svg>
 		<p>gridicons-shipping</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-sign-out">
-		<use xlink:href="#gridicons-sign-out" />
+		<use xlink:href="gridicons.svg#gridicons-sign-out" />
 		</svg>
 		<p>gridicons-sign-out</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-spam">
-		<use xlink:href="#gridicons-spam" />
+		<use xlink:href="gridicons.svg#gridicons-spam" />
 		</svg>
 		<p>gridicons-spam</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-speaker">
-		<use xlink:href="#gridicons-speaker" />
+		<use xlink:href="gridicons.svg#gridicons-speaker" />
 		</svg>
 		<p>gridicons-speaker</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-special-character">
-		<use xlink:href="#gridicons-special-character" />
+		<use xlink:href="gridicons.svg#gridicons-special-character" />
 		</svg>
 		<p>gridicons-special-character</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-star-outline">
-		<use xlink:href="#gridicons-star-outline" />
+		<use xlink:href="gridicons.svg#gridicons-star-outline" />
 		</svg>
 		<p>gridicons-star-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-star">
-		<use xlink:href="#gridicons-star" />
+		<use xlink:href="gridicons.svg#gridicons-star" />
 		</svg>
 		<p>gridicons-star</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-stats-alt">
-		<use xlink:href="#gridicons-stats-alt" />
+		<use xlink:href="gridicons.svg#gridicons-stats-alt" />
 		</svg>
 		<p>gridicons-stats-alt</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-stats">
-		<use xlink:href="#gridicons-stats" />
+		<use xlink:href="gridicons.svg#gridicons-stats" />
 		</svg>
 		<p>gridicons-stats</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-status">
-		<use xlink:href="#gridicons-status" />
+		<use xlink:href="gridicons.svg#gridicons-status" />
 		</svg>
 		<p>gridicons-status</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-strikethrough">
-		<use xlink:href="#gridicons-strikethrough" />
+		<use xlink:href="gridicons.svg#gridicons-strikethrough" />
 		</svg>
 		<p>gridicons-strikethrough</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-sync">
-		<use xlink:href="#gridicons-sync" />
+		<use xlink:href="gridicons.svg#gridicons-sync" />
 		</svg>
 		<p>gridicons-sync</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-tablet">
-		<use xlink:href="#gridicons-tablet" />
+		<use xlink:href="gridicons.svg#gridicons-tablet" />
 		</svg>
 		<p>gridicons-tablet</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-tag">
-		<use xlink:href="#gridicons-tag" />
+		<use xlink:href="gridicons.svg#gridicons-tag" />
 		</svg>
 		<p>gridicons-tag</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-text-color">
-		<use xlink:href="#gridicons-text-color" />
+		<use xlink:href="gridicons.svg#gridicons-text-color" />
 		</svg>
 		<p>gridicons-text-color</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-themes">
-		<use xlink:href="#gridicons-themes" />
+		<use xlink:href="gridicons.svg#gridicons-themes" />
 		</svg>
 		<p>gridicons-themes</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-thumbs-up">
-		<use xlink:href="#gridicons-thumbs-up" />
+		<use xlink:href="gridicons.svg#gridicons-thumbs-up" />
 		</svg>
 		<p>gridicons-thumbs-up</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-time">
-		<use xlink:href="#gridicons-time" />
+		<use xlink:href="gridicons.svg#gridicons-time" />
 		</svg>
 		<p>gridicons-time</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-trash">
-		<use xlink:href="#gridicons-trash" />
+		<use xlink:href="gridicons.svg#gridicons-trash" />
 		</svg>
 		<p>gridicons-trash</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-trophy">
-		<use xlink:href="#gridicons-trophy" />
+		<use xlink:href="gridicons.svg#gridicons-trophy" />
 		</svg>
 		<p>gridicons-trophy</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-types">
-		<use xlink:href="#gridicons-types" />
+		<use xlink:href="gridicons.svg#gridicons-types" />
 		</svg>
 		<p>gridicons-types</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-underline">
-		<use xlink:href="#gridicons-underline" />
+		<use xlink:href="gridicons.svg#gridicons-underline" />
 		</svg>
 		<p>gridicons-underline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-undo">
-		<use xlink:href="#gridicons-undo" />
+		<use xlink:href="gridicons.svg#gridicons-undo" />
 		</svg>
 		<p>gridicons-undo</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-user-add">
-		<use xlink:href="#gridicons-user-add" />
+		<use xlink:href="gridicons.svg#gridicons-user-add" />
 		</svg>
 		<p>gridicons-user-add</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-user-circle">
-		<use xlink:href="#gridicons-user-circle" />
+		<use xlink:href="gridicons.svg#gridicons-user-circle" />
 		</svg>
 		<p>gridicons-user-circle</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-user">
-		<use xlink:href="#gridicons-user" />
+		<use xlink:href="gridicons.svg#gridicons-user" />
 		</svg>
 		<p>gridicons-user</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-video-camera">
-		<use xlink:href="#gridicons-video-camera" />
+		<use xlink:href="gridicons.svg#gridicons-video-camera" />
 		</svg>
 		<p>gridicons-video-camera</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-video">
-		<use xlink:href="#gridicons-video" />
+		<use xlink:href="gridicons.svg#gridicons-video" />
 		</svg>
 		<p>gridicons-video</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-visible">
-		<use xlink:href="#gridicons-visible" />
+		<use xlink:href="gridicons.svg#gridicons-visible" />
 		</svg>
 		<p>gridicons-visible</p>
 	</div>

--- a/svg-sprite/index.html
+++ b/svg-sprite/index.html
@@ -81,1270 +81,1021 @@ window.onload = function () {
         }
     }
 }
+
+// SVG for Everybody
+!function(a,b){"function"==typeof define&&define.amd?define([],function(){return a.svg4everybody=b()}):"object"==typeof module&&module.exports?module.exports=b():a.svg4everybody=b()}(this,function(){function a(a,b,c){if(c){var d=document.createDocumentFragment(),e=!b.hasAttribute("viewBox")&&c.getAttribute("viewBox");e&&b.setAttribute("viewBox",e);for(var f=c.cloneNode(!0);f.childNodes.length;)d.appendChild(f.firstChild);a.appendChild(d)}}function b(b){b.onreadystatechange=function(){if(4===b.readyState){var c=b._cachedDocument;c||(c=b._cachedDocument=document.implementation.createHTMLDocument(""),c.body.innerHTML=b.responseText,b._cachedTarget={}),b._embeds.splice(0).map(function(d){var e=b._cachedTarget[d.id];e||(e=b._cachedTarget[d.id]=c.getElementById(d.id)),a(d.parent,d.svg,e)})}},b.onreadystatechange()}function c(c){function e(){for(var c=0;c<m.length;){var h=m[c],i=h.parentNode,j=d(i);if(j){var n=h.getAttribute("xlink:href")||h.getAttribute("href");if(f&&(!g.validate||g.validate(n,j,h))){i.removeChild(h);var o=n.split("#"),p=o.shift(),q=o.join("#");if(p.length){var r=k[p];r||(r=k[p]=new XMLHttpRequest,r.open("GET",p),r.send(),r._embeds=[]),r._embeds.push({parent:i,svg:j,id:q}),b(r)}else a(i,document.getElementById(q))}}else++c}l(e,67)}var f,g=Object(c),h=/\bTrident\/[567]\b|\bMSIE (?:9|10)\.0\b/,i=/\bAppleWebKit\/(\d+)\b/,j=/\bEdge\/12\.(\d+)\b/;f="polyfill"in g?g.polyfill:h.test(navigator.userAgent)||(navigator.userAgent.match(j)||[])[1]<10547||(navigator.userAgent.match(i)||[])[1]<537;var k={},l=window.requestAnimationFrame||setTimeout,m=document.getElementsByTagName("use");f&&e()}function d(a){for(var b=a;"svg"!==b.nodeName.toLowerCase()&&(b=b.parentNode););return b}return c});svg4everybody();
 </script>
 </head>
 <body>
 
 <h1>Gridicons</h1>
 
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="width:0;height:0;visibility:hidden;"><symbol viewBox="0 0 24 24" id="gridicons-add-image"><title>gridicons-add-image</title> <g> <path d="M23,4v2h-3v3h-2V6h-3V4h3V1h2v3H23z M14.5,11c0.828,0,1.5-0.672,1.5-1.5S15.328,8,14.5,8S13,8.672,13,9.5
-		S13.672,11,14.5,11z M18,14.234l-0.513-0.57c-0.794-0.885-2.181-0.885-2.976,0l-0.656,0.731L9,9l-3,3.333V6h7V4H6
-		C4.895,4,4,4.895,4,6v12c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2v-7h-2V14.234z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-add-outline"><title>gridicons-add-outline</title> <g> <path d="M12,4c4.411,0,8,3.589,8,8s-3.589,8-8,8s-8-3.589-8-8S7.589,4,12,4 M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10
-		s10-4.477,10-10S17.523,2,12,2L12,2z M17,11h-4V7h-2v4H7v2h4v4h2v-4h4V11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-add"><title>gridicons-add</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10s10-4.477,10-10C22,6.477,17.523,2,12,2z M17,13h-4v4h-2v-4H7v-2h4V7h2
-		v4h4V13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-center"><title>gridicons-align-center</title> <g> <path d="M4,19h16v-2H4V19z M17,13H7v2h10V13z M4,9v2h16V9H4z M17,5H7v2h10V5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-image-center"><title>gridicons-align-image-center</title> <g> <path d="M3,5h18v2H3V5z M3,19h18v-2H3V19z M8,15h8V9H8V15z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-image-left"><title>gridicons-align-image-left</title> <g> <path d="M3,5h18v2H3V5z M3,19h18v-2H3V19z M3,15h8V9H3V15z M13,15h8v-2h-8V15z M13,11h8V9h-8V11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-image-none"><title>gridicons-align-image-none</title> <g> <path d="M21,7H3V5h18V7z M21,17H3v2h18V17z M11,9H3v6h8V9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-image-right"><title>gridicons-align-image-right</title> <g> <path d="M21,7H3V5h18V7z M21,17H3v2h18V17z M21,9h-8v6h8V9z M11,13H3v2h8V13z M11,9H3v2h8V9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-justify"><title>gridicons-align-justify</title> <g> <path d="M4,19h16v-2H4V19z M20,13H4v2h16V13z M4,9v2h16V9H4z M20,5L4,5v2h16V5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-left"><title>gridicons-align-left</title> <g> <path d="M4,19h16v-2H4V19z M14,13H4v2h10V13z M4,9v2h16V9H4z M14,5H4v2h10V5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-align-right"><title>gridicons-align-right</title> <g> <path d="M20,17H4v2h16V17z M10,15h10v-2H10V15z M4,9v2h16V9H4z M10,7h10V5H10V7z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-arrow-down"><title>gridicons-arrow-down</title> <g> <path d="M11,4v12.17l-5.59-5.59L4,12l8,8l8-8l-1.41-1.41L13,16.17V4H11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-arrow-left"><title>gridicons-arrow-left</title> <g> <path d="M20,11H7.83l5.59-5.59L12,4l-8,8l8,8l1.41-1.41L7.83,13H20V11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-arrow-right"><title>gridicons-arrow-right</title> <g> <path d="M12,4l-1.41,1.41L16.17,11H4v2h12.17l-5.58,5.59L12,20l8-8L12,4z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-arrow-up"><title>gridicons-arrow-up</title> <g> <path d="M13,20V7.83l5.59,5.59L20,12l-8-8l-8,8l1.41,1.41L11,7.83V20H13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-aside"><title>gridicons-aside</title> <g> <path d="M14,20l6-6V6c0-1.105-0.895-2-2-2H6C4.895,4,4,4.895,4,6v12c0,1.105,0.895,2,2,2H14z M6,6h12v6h-4c-1.105,0-2,0.895-2,2v4
-		H6V6z M16,10H8V8h8V10z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-attachment"><title>gridicons-attachment</title> <g> <path d="M14,1c-2.762,0-5,2.238-5,5v10c0,1.657,1.343,3,3,3c1.657,0,2.99-1.343,2.99-3V6H13v10c0,0.553-0.447,1-1,1
-		c-0.553,0-1-0.447-1-1V6c0-1.657,1.343-3,3-3c1.657,0,3,1.343,3,3v10.125C17,18.887,14.762,21,12,21c-2.762,0-5-2.238-5-5v-5H5v5
-		c0,3.866,3.134,7,7,7c3.866,0,6.99-3.134,6.99-7V6C18.99,3.238,16.762,1,14,1z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-audio"><title>gridicons-audio</title> <g> <path d="M8,4v10.184C7.686,14.072,7.353,14,7,14c-1.657,0-3,1.343-3,3s1.343,3,3,3s3-1.343,3-3V7h7v4.184
-		C16.686,11.072,16.353,11,16,11c-1.657,0-3,1.343-3,3s1.343,3,3,3s3-1.343,3-3V4H8z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-bell"><title>gridicons-bell</title> <g> <path d="M6.14,14.969l2.828,2.828c-0.362,0.362-0.862,0.586-1.414,0.586c-1.105,0-2-0.895-2-2
-		C5.555,15.831,5.778,15.331,6.14,14.969z M15.007,20.294L14.301,21L3,9.699l0.706-0.706L4.808,9.15
-		c0.754,0.108,1.689-0.122,2.077-0.51l3.885-3.884c2.34-2.34,6.135-2.34,8.475,0s2.34,6.135,0,8.475l-3.885,3.885
-		c-0.388,0.388-0.618,1.323-0.51,2.077L15.007,20.294z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-block"><title>gridicons-block</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10C22,6.477,17.523,2,12,2z M4,12
-		c0-4.418,3.582-8,8-8c1.848,0,3.545,0.633,4.9,1.686L5.686,16.9C4.633,15.545,4,13.848,4,12z M12,20
-		c-1.848,0-3.546-0.633-4.9-1.686L18.314,7.1C19.367,8.455,20,10.152,20,12C20,16.418,16.418,20,12,20z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-bold"><title>gridicons-bold</title> <g> <path d="M7,5.009h4.547c2.126,0,3.671,0.303,4.632,0.907c0.962,0.605,1.442,1.567,1.442,2.887c0,0.896-0.211,1.63-0.631,2.205
-		c-0.421,0.574-0.98,0.919-1.678,1.036v0.103c0.951,0.212,1.637,0.608,2.057,1.189C17.79,13.916,18,14.688,18,15.652
-		c0,1.367-0.494,2.434-1.482,3.199C15.529,19.617,14.186,20,12.491,20H7V5.009z M10,10.946h2.027c0.862,0,1.486-0.133,1.872-0.4
-		c0.387-0.267,0.579-0.708,0.579-1.323c0-0.574-0.21-0.986-0.63-1.236c-0.421-0.249-1.087-0.374-1.996-0.374H10V10.946z M10,13.469
-		v3.906h2.253c0.876,0,1.521-0.167,1.939-0.502c0.417-0.335,0.626-0.848,0.626-1.539c0-1.244-0.889-1.865-2.668-1.865H10z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-book"><title>gridicons-book</title> <g> <g> <g> <rect x="4" y="3" width="2" height="18"/> <path d="M18,3H7v18h11c1.1,0,2-0.9,2-2V5C20,3.9,19.1,3,18,3z M16,9h-6V8h6V9z M16,7h-6V6h6V7z"/> </g> </g> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-bookmark-outline"><title>gridicons-bookmark-outline</title> <g> <path d="M17,5v12.554l-5-2.857l-5,2.857V5H17 M17,3H7C5.895,3,5,3.896,5,5v16l7-4l7,4V5C19,3.896,18.104,3,17,3L17,3z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-bookmark"><title>gridicons-bookmark</title> <g> <path d="M17,3H7C5.895,3,5,3.896,5,5v16l7-4l7,4V5C19,3.896,18.104,3,17,3z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-briefcase"><title>gridicons-briefcase</title> <g> <path d="M14,15h-4v-2H2v6c0,1.105,0.895,2,2,2h16c1.105,0,2-0.895,2-2v-6h-8V15z M20,6h-2V4c0-1.105-0.895-2-2-2H8
-		C6.895,2,6,2.895,6,4v2H4C2.895,6,2,6.895,2,8v4h20V8C22,6.895,21.105,6,20,6z M16,6H8V4h8V6z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-calendar"><title>gridicons-calendar</title> <g> <path d="M19,4h-1V2h-2v2H8V2H6v2H5C3.895,4,3,4.896,3,6v13c0,1.104,0.895,2,2,2h14c1.104,0,2-0.896,2-2V6C21,4.896,20.104,4,19,4z
-		 M19,19H5V8h14V19z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-camera"><title>gridicons-camera</title> <g> <path d="M17,12c0,1.7-1.3,3-3,3s-3-1.3-3-3s1.3-3,3-3S17,10.3,17,12z M22,7v11c0,1.1-0.9,2-2,2H4c-1.1,0-2-0.9-2-2V7
-		c0-1.1,0.9-2,2-2V4h4v1h2l1-2h6l1,2h2C21.1,5,22,5.9,22,7z M7.5,9c0-0.8-0.7-1.5-1.5-1.5S4.5,8.2,4.5,9s0.7,1.5,1.5,1.5
-		S7.5,9.8,7.5,9z M19,12c0-2.8-2.2-5-5-5s-5,2.2-5,5s2.2,5,5,5S19,14.8,19,12z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-caption"><title>gridicons-caption</title> <g> <path d="M20,15l2-2v5c0,1.105-0.895,2-2,2H4c-1.105,0-2-0.895-2-2V6c0-1.105,0.895-2,2-2h13l-2,2H4v12h16V15z M22.44,6.44
-		l-0.88-0.88c-0.586-0.585-1.534-0.585-2.12,0L12,13v2H6v2h9v-1l7.44-7.44C23.025,7.974,23.025,7.026,22.44,6.44z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cart"><title>gridicons-cart</title> <g> <path d="M9,20c0,1.1-0.9,2-2,2s-1.99-0.9-1.99-2S5.9,18,7,18S9,18.9,9,20z M17,18c-1.1,0-1.99,0.9-1.99,2s0.89,2,1.99,2s2-0.9,2-2
-		S18.1,18,17,18z M17.396,13c0.937,0,1.749-0.651,1.952-1.566L21,5H7V4c0-1.105-0.895-2-2-2H3v2h2v1v8v2c0,1.105,0.895,2,2,2h12
-		c0-1.105-0.895-2-2-2H7v-2H17.396z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-chat"><title>gridicons-chat</title> <g> <path d="M20,4h-8c-1.1,0-2,0.9-2,2v2h2c1.7,0,3,1.3,3,3v2h2v3.5l3.3-2.3c1.1-0.8,1.7-2,1.7-3.3V6C22,4.9,21.1,4,20,4z"/> <g> <path d="M14,11v5c0,1.1-0.9,2-2,2H7v3.5l-3.3-2.3c-1.1-0.8-1.7-2-1.7-3.3V11c0-1.1,0.9-2,2-2h8C13.1,9,14,9.9,14,11z"/> </g> </g> </symbol><symbol viewBox="0 0 24 24" id="gridicons-checkmark-circle"><title>gridicons-checkmark-circle</title> <g> <path d="M11,17.768l-4.884-4.884l1.768-1.768L11,14.232l8.658-8.658C17.823,3.391,15.075,2,12,2C6.477,2,2,6.477,2,12
-		s4.477,10,10,10s10-4.477,10-10c0-1.528-0.353-2.971-0.966-4.266L11,17.768z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-checkmark"><title>gridicons-checkmark</title> <g> <polygon points="9,19.414 2.293,12.707 3.707,11.293 9,16.586 20.293,5.293 21.707,6.707 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-chevron-down"><title>gridicons-chevron-down</title> <g> <polygon points="20,9 12,17 4,9 5.414,7.586 12,14.172 18.586,7.586 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-chevron-left"><title>gridicons-chevron-left</title> <g> <polygon points="14,20 6,12 14,4 15.414,5.414 8.828,12 15.414,18.586 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-chevron-right"><title>gridicons-chevron-right</title> <g> <polygon points="10,20 18,12 10,4 8.586,5.414 15.172,12 8.586,18.586 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-chevron-up"><title>gridicons-chevron-up</title> <g> <polygon points="4,15 12,7 20,15 18.586,16.414 12,9.828 5.414,16.414 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-clear-formatting"><title>gridicons-clear-formatting</title> <g> <path d="M10.837,10.163l-4.6,4.6L10,4h4l0.777,2.223l-2.144,2.144l-0.627-2.092L10.837,10.163z M16.332,10.669L19.244,19H15.82
-		l-1.049-3.5H11.5L5,22l-1.5-1.5l17-17L22,5L16.332,10.669z M14.021,12.979l-0.031,0.031L14.022,13L14.021,12.979z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-clipboard"><title>gridicons-clipboard</title> <g> <path d="M16,18H8v-2h8V18z M16,12H8v2h8V12z M18,3h-2v2h2v15H6V5h2V3H6C4.895,3,4,3.895,4,5v15c0,1.105,0.895,2,2,2h12
-		c1.105,0,2-0.895,2-2V5C20,3.895,19.105,3,18,3z M14,5V4c0-1.105-0.895-2-2-2s-2,0.895-2,2v1C8.895,5,8,5.895,8,7v1h8V7
-		C16,5.895,15.105,5,14,5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cloud-download"><title>gridicons-cloud-download</title> <g> <path d="M18,9c-0.009,0-0.017,0.002-0.025,0.003C17.72,5.646,14.922,3,11.5,3C7.91,3,5,5.91,5,9.5c0,0.524,0.069,1.031,0.186,1.519
-		C5.123,11.016,5.064,11,5,11c-2.209,0-4,1.791-4,4c0,1.202,0.541,2.267,1.38,3h18.593C22.196,17.089,23,15.643,23,14
-		C23,11.239,20.761,9,18,9z M12,16l-4-5h3V8h2v3h3L12,16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cloud-outline"><title>gridicons-cloud-outline</title> <g> <path d="M11.5,5c2.336,0,4.304,1.825,4.481,4.154l0.141,1.861l1.867-0.013l0.093-0.001C19.698,11.044,21,12.373,21,14
-		c0,0.748-0.28,1.452-0.783,2H3.279C3.124,15.744,3,15.411,3,15c0-1.074,0.851-1.953,1.915-1.998
-		c0.059,0.007,0.118,0.012,0.178,0.015l2.659,0.124l-0.621-2.588C7.043,10.186,7,9.842,7,9.5C7,7.019,9.019,5,11.5,5 M11.5,3
-		C7.91,3,5,5.91,5,9.5c0,0.524,0.069,1.031,0.186,1.519C5.123,11.016,5.064,11,5,11c-2.209,0-4,1.791-4,4
-		c0,1.202,0.541,2.267,1.38,3h18.593C22.196,17.089,23,15.643,23,14c0-2.761-2.239-5-5-5c-0.009,0-0.017,0.002-0.025,0.002
-		C17.72,5.646,14.922,3,11.5,3L11.5,3z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cloud-upload"><title>gridicons-cloud-upload</title> <g> <path d="M18,9c-0.009,0-0.017,0.002-0.025,0.003C17.72,5.646,14.922,3,11.5,3C7.91,3,5,5.91,5,9.5c0,0.524,0.069,1.031,0.186,1.519
-		C5.123,11.016,5.064,11,5,11c-2.209,0-4,1.791-4,4c0,1.202,0.541,2.267,1.38,3h18.593C22.196,17.089,23,15.643,23,14
-		C23,11.239,20.761,9,18,9z M13,13v3h-2v-3H8l4-5l4,5H13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cloud"><title>gridicons-cloud</title> <g> <path d="M18,9c-0.009,0-0.017,0.002-0.025,0.003C17.72,5.646,14.922,3,11.5,3C7.91,3,5,5.91,5,9.5c0,0.524,0.069,1.031,0.186,1.519
-		C5.123,11.016,5.064,11,5,11c-2.209,0-4,1.791-4,4c0,1.202,0.541,2.267,1.38,3h18.593C22.196,17.089,23,15.643,23,14
-		C23,11.239,20.761,9,18,9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-code"><title>gridicons-code</title> <g> <path d="M4.83,12l4.58,4.59L8,18l-6-6l6-6l1.41,1.41L4.83,12z M14.59,16.59L16,18l6-6l-6-6l-1.41,1.41L19.17,12L14.59,16.59z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cog"><title>gridicons-cog</title> <g> <path d="M20,12c0-0.568-0.061-1.122-0.174-1.656l1.834-1.612l-2-3.464l-2.322,0.786c-0.819-0.736-1.787-1.308-2.859-1.657L14,2h-4
-		L9.521,4.396c-1.072,0.349-2.04,0.921-2.859,1.657L4.34,5.268l-2,3.464l1.834,1.612C4.061,10.878,4,11.432,4,12
-		s0.061,1.122,0.174,1.656L2.34,15.268l2,3.464l2.322-0.786c0.819,0.736,1.787,1.308,2.859,1.657L10,22h4l0.479-2.396
-		c1.072-0.349,2.039-0.921,2.859-1.657l2.322,0.786l2-3.464l-1.834-1.612C19.939,13.122,20,12.568,20,12z M12,16
-		c-2.209,0-4-1.791-4-4c0-2.209,1.791-4,4-4c2.209,0,4,1.791,4,4C16,14.209,14.209,16,12,16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-comment"><title>gridicons-comment</title> <g> <path d="M3,6v9c0,1.105,0.895,2,2,2h9v5l5.325-3.804C20.376,17.446,21,16.233,21,14.942V6c0-1.105-0.895-2-2-2H5
-		C3.895,4,3,4.895,3,6z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-computer"><title>gridicons-computer</title> <g> <path d="M20,2H4C2.896,2,2,2.896,2,4v12c0,1.104,0.896,2,2,2h6l0,2H7v2h10v-2h-3l0-2h6c1.104,0,2-0.896,2-2V4
-		C22,2.896,21.104,2,20,2z M20,16H4V4h16V16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-coupon"><title>gridicons-coupon</title> <g> <path d="M13,16v2h-2v-2H13z M16,13h2v-2h-2V13z M18,21h-2v2h2V21z M21,16v2h2v-2H21z M20,13c0.552,0,1,0.448,1,1h2
-		c0-1.657-1.343-3-3-3V13z M21,20c0,0.552-0.448,1-1,1v2c1.657,0,3-1.343,3-3H21z M14,21c-0.552,0-1-0.448-1-1h-2
-		c0,1.657,1.343,3,3,3V21z M17.21,15.79c-0.781,0.781-2.047,0.782-2.828,0.002c-0.001-0.001-0.001-0.001-0.002-0.002L10,11.41
-		l-1.43,1.44C8.849,13.356,8.997,13.923,9,14.5C9,16.433,7.433,18,5.5,18S2,16.433,2,14.5S3.567,11,5.5,11
-		c0.577,0.003,1.144,0.151,1.65,0.43L8.59,10L7.15,8.57C6.644,8.849,6.077,8.997,5.5,9C3.567,9,2,7.433,2,5.5S3.567,2,5.5,2
-		S9,3.567,9,5.5C8.997,6.077,8.849,6.644,8.57,7.15L10,8.59l3.88-3.88c0.781-0.781,2.047-0.782,2.828-0.002
-		c0.001,0.001,0.001,0.001,0.002,0.002L11.41,10L17.21,15.79z M5.5,7C6.328,7,7,6.328,7,5.5S6.328,4,5.5,4S4,4.672,4,5.5
-		S4.672,7,5.5,7z M7,14.5C7,13.672,6.328,13,5.5,13S4,13.672,4,14.5S4.672,16,5.5,16S7,15.328,7,14.5L7,14.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-create"><title>gridicons-create</title> <g> <path d="M21,11v8c0,1.105-0.895,2-2,2H5c-1.105,0-2-0.895-2-2V5c0-1.105,0.895-2,2-2h8l-2,2H5v14h14v-6L21,11z M7,17h3l7.5-7.5
-		l-3-3L7,14V17z M16.939,4.061L15.5,5.5l3,3l1.439-1.439c0.586-0.586,0.586-1.536,0-2.121l-0.879-0.879
-		C18.475,3.475,17.525,3.475,16.939,4.061z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-credit-card"><title>gridicons-credit-card</title> <g> <path d="M20,4H4C2.895,4,2,4.895,2,6v12c0,1.105,0.895,2,2,2h16c1.105,0,2-0.895,2-2V6C22,4.895,21.105,4,20,4z M20,6v2H4V6H20z
-		 M4,18v-6h16v6H4z M6,14h7v2H6V14z M15,14h3v2h-3V14z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-crop"><title>gridicons-crop</title> <g> <path d="M22,16h-4V8c0-1.105-0.895-2-2-2H8V2H6v4H2v2h4v8c0,1.105,0.895,2,2,2h8v4h2v-4h4V16z M8,16V8h8v8H8z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cross-circle"><title>gridicons-cross-circle</title> <g> <path d="M19.1,4.9C15.2,1,8.8,1,4.9,4.9S1,15.2,4.9,19.1s10.2,3.9,14.1,0S23,8.8,19.1,4.9z M14.8,16.2L12,13.4l-2.8,2.8l-1.4-1.4
-		l2.8-2.8L7.8,9.2l1.4-1.4l2.8,2.8l2.8-2.8l1.4,1.4L13.4,12l2.8,2.8L14.8,16.2z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cross-small"><title>gridicons-cross-small</title> <g> <path d="M17.705,7.705l-1.41-1.41L12,10.59L7.705,6.295l-1.41,1.41L10.59,12l-4.295,4.295l1.41,1.41L12,13.41l4.295,4.295
-		l1.41-1.41L13.41,12L17.705,7.705z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-cross"><title>gridicons-cross</title><g><path d="M18.36,19.78L12,13.41,5.64,19.78,4.22,18.36,10.59,12,4.22,5.64,5.64,4.22,12,10.59l6.36-6.36,1.41,1.41L13.41,12l6.36,6.36Z"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-custom-post-type"><title>gridicons-custom-post-type</title> <g> <path d="M19,3H5C3.895,3,3,3.895,3,5v14c0,1.105,0.895,2,2,2h14c1.105,0,2-0.895,2-2V5C21,3.895,20.105,3,19,3z M6,6h5v5H6V6z
-		 M10.5,19C9.119,19,8,17.881,8,16.5S9.119,14,10.5,14c1.381,0,2.5,1.119,2.5,2.5S11.881,19,10.5,19z M13.5,13l3-5l3,5H13.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-customize"><title>gridicons-customize</title> <g> <path d="M2,6c0-1.505,0.78-3.08,2-4c0,0.845,0.69,2,2,2c1.657,0,3,1.343,3,3c0,0.386-0.079,0.752-0.212,1.091
-		c0.739,0.593,1.476,1.188,2.191,1.808l-2.08,2.08c-0.62-0.715-1.215-1.453-1.808-2.191C6.752,9.921,6.386,10,6,10
-		C3.79,10,2,8.21,2,6z M14.152,12.848l1.341-1.341C16.099,11.812,16.775,12,17.5,12c2.485,0,4.5-2.015,4.5-4.5
-		c0-0.725-0.188-1.401-0.493-2.007L18,9l-2-2l3.507-3.507C18.901,3.188,18.225,3,17.5,3C15.015,3,13,5.015,13,7.5
-		c0,0.725,0.188,1.401,0.493,2.007L3,20l2,2l6.848-6.848c1.885,1.928,3.874,3.753,5.977,5.449l1.425,1.149l1.5-1.5l-1.149-1.425
-		C17.905,16.722,16.08,14.733,14.152,12.848z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-domains"><title>gridicons-domains</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10s10-4.477,10-10C22,6.477,17.523,2,12,2z M18.918,8h-3.215
-		c-0.188-1.424-0.42-2.651-0.565-3.357C16.731,5.325,18.054,6.513,18.918,8z M13.014,4.072C13.082,4.424,13.401,6.11,13.659,8
-		h-3.318c0.258-1.89,0.577-3.576,0.645-3.928C11.319,4.029,11.656,4,12,4S12.681,4.029,13.014,4.072z M14,12
-		c0,0.598-0.043,1.286-0.109,2h-3.782C10.043,13.286,10,12.598,10,12s0.043-1.286,0.109-2h3.782C13.957,10.714,14,11.402,14,12z
-		 M8.862,4.643C8.717,5.349,8.485,6.576,8.297,8H5.082C5.946,6.513,7.269,5.325,8.862,4.643z M4.263,10h3.821
-		C8.033,10.668,8,11.344,8,12s0.033,1.332,0.085,2H4.263C4.097,13.359,4,12.692,4,12S4.098,10.641,4.263,10z M5.082,16h3.215
-		c0.188,1.424,0.42,2.65,0.565,3.357C7.269,18.675,5.946,17.487,5.082,16z M10.986,19.928c-0.068-0.353-0.388-2.038-0.645-3.928
-		h3.318c-0.258,1.89-0.577,3.576-0.645,3.928C12.681,19.971,12.344,20,12,20S11.319,19.971,10.986,19.928z M15.138,19.357
-		c0.145-0.707,0.377-1.933,0.565-3.357h3.215C18.054,17.487,16.731,18.675,15.138,19.357z M19.737,14h-3.821
-		C15.967,13.332,16,12.656,16,12s-0.033-1.332-0.085-2h3.821C19.902,10.641,20,11.308,20,12S19.903,13.359,19.737,14z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-dropdown"><title>gridicons-dropdown</title> <g> <polygon points="7,10 12,15 17,10 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-ellipsis-circle"><title>gridicons-ellipsis-circle</title> <g> <path d="M12,2C6.5,2,2,6.5,2,12s4.5,10,10,10s10-4.5,10-10S17.5,2,12,2z M7.5,13.5C6.7,13.5,6,12.8,6,12s0.7-1.5,1.5-1.5
-		S9,11.2,9,12S8.3,13.5,7.5,13.5z M12,13.5c-0.8,0-1.5-0.7-1.5-1.5s0.7-1.5,1.5-1.5s1.5,0.7,1.5,1.5S12.8,13.5,12,13.5z M16.5,13.5
-		c-0.8,0-1.5-0.7-1.5-1.5s0.7-1.5,1.5-1.5c0.8,0,1.5,0.7,1.5,1.5S17.3,13.5,16.5,13.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-ellipsis"><title>gridicons-ellipsis</title> <g> <path d="M7,12c0,1.104-0.896,2-2,2s-2-0.896-2-2s0.896-2,2-2S7,10.896,7,12z M19,10c-1.104,0-2,0.896-2,2s0.896,2,2,2s2-0.896,2-2
-		S20.104,10,19,10z M12,10c-1.104,0-2,0.896-2,2s0.896,2,2,2s2-0.896,2-2S13.104,10,12,10z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-external"><title>gridicons-external</title> <g> <path d="M19,13v6c0,1.105-0.895,2-2,2H5c-1.105,0-2-0.895-2-2V7c0-1.105,0.895-2,2-2h6v2H5v12h12v-6H19z M13,3v2h4.586
-		l-7.793,7.793l1.414,1.414L19,6.414V11h2V3H13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-filter"><title>gridicons-filter</title> <g> <g> <path d="M18.595,4H5.415C4.863,3.997,4.412,4.442,4.409,4.994C4.408,5.263,4.514,5.521,4.705,5.71l5.3,5.29v6l4,4V11l5.29-5.29
-			c0.392-0.389,0.395-1.022,0.006-1.414C19.114,4.108,18.86,4.001,18.595,4z"/> </g> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-flag"><title>gridicons-flag</title> <g> <path d="M15,6c0-1.105-0.895-2-2-2H5v17h2v-7h5c0,1.105,0.895,2,2,2h6V6H15z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-flip-horizontal"><title>gridicons-flip-horizontal</title> <g> <path d="M20,18v-5h3v-2h-3V6c0-1.105-0.895-2-2-2H6C4.895,4,4,4.895,4,6v5H1v2h3v5c0,1.105,0.895,2,2,2h12
-		C19.105,20,20,19.105,20,18z M6,6h12v5H6V6z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-flip-vertical"><title>gridicons-flip-vertical</title> <g> <path d="M18,4h-5V1h-2v3H6C4.895,4,4,4.895,4,6v12c0,1.105,0.895,2,2,2h5v3h2v-3h5c1.105,0,2-0.895,2-2V6C20,4.895,19.105,4,18,4z
-		 M6,18V6h5v12H6z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-folder-multiple"><title>gridicons-folder-multiple</title> <g> <path d="M4,8L4,8c-1.105,0-2,0.895-2,2v10c0,1.1,0.9,2,2,2h14c1.105,0,2-0.895,2-2v0H4V8z M20,18H8c-1.105,0-2-0.895-2-2V6
-		c0-1.105,0.895-2,2-2h3c1.105,0,2,0.895,2,2v0h7c1.105,0,2,0.895,2,2v8C22,17.105,21.105,18,20,18z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-folder"><title>gridicons-folder</title> <g> <path d="M18,19H6c-1.1,0-2-0.9-2-2V7c0-1.1,0.9-2,2-2h3c1.1,0,2,0.9,2,2l0,0h7c1.1,0,2,0.9,2,2v8C20,18.1,19.1,19,18,19z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-fullscreen-exit"><title>gridicons-fullscreen-exit</title><g><path d="M14,10V4h2V6.59l3.29-3.29,1.41,1.41L17.41,8H20v2ZM4,10V8H6.59L3.29,4.71,4.71,3.29,8,6.59V4h2v6Zm16,4v2H17.41l3.29,3.29-1.41,1.41L16,17.41V20H14V14ZM10,14v6H8V17.41L4.71,20.71,3.29,19.29,6.59,16H4V14Z"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-fullscreen"><title>gridicons-fullscreen</title><g><path d="M21,3V9H19V6.41L15.71,9.71,14.29,8.29,17.59,5H15V3ZM3,3V9H5V6.41L8.29,9.71,9.71,8.29,6.41,5H9V3ZM21,21V15H19v2.59l-3.29-3.29-1.41,1.41L17.59,19H15v2ZM9,21V19H6.41l3.29-3.29L8.29,14.29,5,17.59V15H3v6Z"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-globe"><title>gridicons-globe</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10s10-4.477,10-10C22,6.477,17.523,2,12,2z M12,20l2-2l1-1v-2h-2v-1l-1-1
-		H9v3l2,2v1.931C7.06,19.436,4,16.072,4,12l1,1h2v-2h2l3-3V6h-2L9,5V4.589C9.927,4.212,10.939,4,12,4s2.073,0.212,3,0.589V6l-1,1v2
-		l1,1l3.13-3.13c0.752,0.897,1.304,1.964,1.606,3.13H18l-2,2v2l1,1h2l0.286,0.286C18.029,18.061,15.239,20,12,20z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-grid"><title>gridicons-grid</title> <g> <path d="M8,8H4V4h4V8z M14,4h-4v4h4V4z M20,4h-4v4h4V4z M8,10H4v4h4V10z M14,10h-4v4h4V10z M20,10h-4v4h4V10z M8,16H4v4h4V16z
-		 M14,16h-4v4h4V16z M20,16h-4v4h4V16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-heading"><title>gridicons-heading</title> <g> <path d="M18,20h-3v-6H9v6H6V5.009h3V11h6V5.009h3V20z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-heart-outline"><title>gridicons-heart-outline</title> <g> <path d="M16.5,4.5c2.206,0,4,1.794,4,4c0,4.669-5.543,8.941-8.5,11.023C9.043,17.441,3.5,13.169,3.5,8.5c0-2.206,1.794-4,4-4
-		c1.298,0,2.522,0.638,3.273,1.706L12,7.953l1.227-1.746C13.978,5.138,15.202,4.5,16.5,4.5 M16.5,3c-1.862,0-3.505,0.928-4.5,2.344
-		C11.005,3.928,9.362,3,7.5,3C4.462,3,2,5.462,2,8.5c0,5.719,6.5,10.438,10,12.85c3.5-2.412,10-7.131,10-12.85
-		C22,5.462,19.538,3,16.5,3L16.5,3z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-heart"><title>gridicons-heart</title> <g> <path d="M16.5,3c-1.862,0-3.505,0.928-4.5,2.344C11.005,3.928,9.362,3,7.5,3C4.462,3,2,5.462,2,8.5c0,5.719,6.5,10.438,10,12.85
-		c3.5-2.412,10-7.131,10-12.85C22,5.462,19.538,3,16.5,3z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-help-outline"><title>gridicons-help-outline</title> <g> <path d="M12,4c4.411,0,8,3.589,8,8s-3.589,8-8,8s-8-3.589-8-8S7.589,4,12,4 M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10
-		s10-4.477,10-10S17.523,2,12,2L12,2z M16,10c0-2.209-1.791-4-4-4s-4,1.791-4,4h2c0-1.103,0.897-2,2-2s2,0.897,2,2s-0.897,2-2,2
-		c-0.552,0-1,0.448-1,1v2h2v-1.141C14.722,13.413,16,11.862,16,10z M13,16h-2v2h2V16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-help"><title>gridicons-help</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10s10-4.477,10-10S17.523,2,12,2z M13,18h-2v-2h2V18z M13,13.859V15h-2v-2
-		c0-0.552,0.448-1,1-1c1.103,0,2-0.897,2-2s-0.897-2-2-2s-2,0.897-2,2H8c0-2.209,1.791-4,4-4s4,1.791,4,4
-		C16,11.862,14.722,13.413,13,13.859z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-history"><title>gridicons-history</title> <g> <g> <path d="M2.12,13.526c0.742,4.781,4.902,8.47,9.881,8.47c5.499,0,9.998-4.499,9.998-9.998S17.501,2,12.002,2
-			C8.704,2,5.802,3.601,4,6l0,0V2.001L2.003,2L2,9h7V7L5.801,6.999l0,0C7.2,5.201,9.502,4,12.002,4C16.4,4,20,7.6,20,11.998
-			s-3.6,7.999-7.999,7.999c-3.878,0-7.132-2.794-7.849-6.471L2.12,13.526z"/> <polygon points="11.002,6.999 11.002,12.301 14.203,16.598 15.803,15.401 13.002,11.7 13.002,6.999 		"/> </g> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-house"><title>gridicons-house</title> <g> <path d="M22,9L12,1L2,9v2h2v10h5v-4c0-1.657,1.343-3,3-3s3,1.343,3,3v4h5V11h2V9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-image-multiple"><title>gridicons-image-multiple</title> <g> <path d="M15,7.5C15,6.672,15.672,6,16.5,6C17.328,6,18,6.672,18,7.5S17.328,9,16.5,9C15.672,9,15,8.328,15,7.5z M4,20h14v0
-		c0,1.105-0.895,2-2,2H4c-1.1,0-2-0.9-2-2V8c0-1.105,0.895-2,2-2h0V20z M22,4v12c0,1.105-0.895,2-2,2H8c-1.105,0-2-0.895-2-2V4
-		c0-1.105,0.895-2,2-2h12C21.105,2,22,2.895,22,4z M8,4v6.333L11,7l4.855,5.395l0.656-0.731c0.795-0.885,2.182-0.885,2.976,0
-		L20,12.234V4H8z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-image"><title>gridicons-image</title> <g> <path d="M13,9.5C13,8.672,13.672,8,14.5,8S16,8.672,16,9.5S15.328,11,14.5,11S13,10.328,13,9.5z M22,6v12c0,1.105-0.895,2-2,2H4
-		c-1.105,0-2-0.895-2-2V6c0-1.105,0.895-2,2-2h16C21.105,4,22,4.895,22,6z M20,6H4v7.444L8,9l5.895,6.55l1.587-1.851
-		c0.798-0.931,2.239-0.931,3.037,0L20,15.427V6z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-indent-left"><title>gridicons-indent-left</title> <g> <path d="M18,20h2V4h-2V20z M2,11h10.172l-2.086-2.086L11.5,7.5L16,12l-4.5,4.5l-1.414-1.414L12.172,13H2V11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-indent-right"><title>gridicons-indent-right</title> <g> <path d="M6,4H4v16h2V4z M22,13H11.828l2.086,2.086L12.5,16.5L8,12l4.5-4.5l1.414,1.414L11.828,11H22V13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-info-outline"><title>gridicons-info-outline</title> <g> <path d="M13,9h-2V7h2V9z M13,11h-2v6h2V11z M12,4c-4.411,0-8,3.589-8,8s3.589,8,8,8s8-3.589,8-8S16.411,4,12,4 M12,2
-		c5.523,0,10,4.477,10,10s-4.477,10-10,10S2,17.523,2,12S6.477,2,12,2L12,2z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-info"><title>gridicons-info</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10s10-4.477,10-10S17.523,2,12,2z M13,17h-2v-6h2V17z M13,9h-2V7h2V9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-ink"><title>gridicons-ink</title> <g> <path d="M5,15c0,3.866,3.134,7,7,7s7-3.134,7-7c0-1.387-0.409-2.677-1.105-3.765h0.007C15.542,7.541,12,2,12,2
-		s-3.542,5.541-5.903,9.235h0.007C5.409,12.323,5,13.613,5,15z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-institution"><title>gridicons-institution</title> <g> <g> <g> <rect x="2" y="19" width="20" height="3"/> <polygon points="12,2 2,6 2,8 22,8 22,6 			"/> <rect x="17" y="10" width="3" height="7"/> <rect x="10.5" y="10" width="3" height="7"/> <rect x="4" y="10" width="3" height="7"/> </g> </g>  </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-italic"><title>gridicons-italic</title> <g> <polygon points="10.536,5 10.109,7 11.609,7 9.263,18 7.763,18 7.336,20 13.464,20 13.89,18 12.39,18 14.737,7 16.237,7 16.664,5 	
-		"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-layout-blocks"><title>gridicons-layout-blocks</title> <g> <path d="M21,7h-2V3c0-1.105-0.895-2-2-2H7C5.895,1,5,1.895,5,3v2H3C1.895,5,1,5.895,1,7v4c0,1.105,0.895,2,2,2h2v8
-		c0,1.105,0.895,2,2,2h10c1.105,0,2-0.895,2-2v-2h2c1.105,0,2-0.895,2-2V9C23,7.895,22.105,7,21,7z M17,21H7v-8h2
-		c1.105,0,2-0.895,2-2V7c0-1.105-0.895-2-2-2H7V3h10v4h-2c-1.105,0-2,0.895-2,2v8c0,1.105,0.895,2,2,2h2V21z M21,17h-6V9h6V17z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-layout"><title>gridicons-layout</title> <g> <path d="M8,20H5c-1.105,0-2-0.895-2-2V6c0-1.105,0.895-2,2-2h3c1.105,0,2,0.895,2,2v12C10,19.105,9.105,20,8,20z M16,10h4
-		c1.105,0,2-0.895,2-2V5c0-1.105-0.895-2-2-2h-4c-1.105,0-2,0.895-2,2v3C14,9.105,14.895,10,16,10z M21,20v-6c0-1.105-0.895-2-2-2
-		h-5c-1.105,0-2,0.895-2,2v6c0,1.105,0.895,2,2,2h5C20.105,22,21,21.105,21,20z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-link-break"><title>gridicons-link-break</title> <g> <path d="M10,11l-2,2H7v-2H10z M19.641,7.36L22,5l-1.5-1.5l-17,17L5,22l9-9h3v-2h-1l2-2c1.103,0,2,0.897,2,2v2c0,1.103-0.897,2-2,2
-		h-1h-3.977c0.913,1.208,2.347,2,3.977,2h1c2.209,0,4-1.791,4-4v-2C22,9.377,21.029,7.987,19.641,7.36z M4.36,16.64L6,15
-		c-1.103,0-2-0.897-2-2v-2c0-1.103,0.897-2,2-2h1h3.977C10.065,7.792,8.631,7,7,7H6c-2.209,0-4,1.791-4,4v2
-		C2,14.623,2.971,16.013,4.36,16.64z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-link"><title>gridicons-link</title> <g> <path d="M17,13H7v-2h10V13z M18,7h-1c-1.631,0-3.065,0.792-3.977,2H17h1c1.103,0,2,0.897,2,2v2c0,1.103-0.897,2-2,2h-1h-3.977
-		c0.913,1.208,2.347,2,3.977,2h1c2.209,0,4-1.791,4-4v-2C22,8.791,20.209,7,18,7z M2,11v2c0,2.209,1.791,4,4,4h1
-		c1.63,0,3.065-0.792,3.977-2H7H6c-1.103,0-2-0.897-2-2v-2c0-1.103,0.897-2,2-2h1h3.977C10.065,7.792,8.631,7,7,7H6
-		C3.791,7,2,8.791,2,11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-list-checkmark"><title>gridicons-list-checkmark</title> <g> <path d="M9.5,15.5L5,20l-2.5-2.5l1.061-1.061L5,17.879l3.439-3.439L9.5,15.5z M10,5v2h11V5H10z M10,19h11v-2H10V19z M10,13h11v-2
-		H10V13z M5,15 M8.439,8.439L5,11.879l-1.439-1.439L2.5,11.5L5,14l4.5-4.5L8.439,8.439z M8.439,2.439L5,5.879L3.561,4.439L2.5,5.5
-		L5,8l4.5-4.5L8.439,2.439z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-list-ordered"><title>gridicons-list-ordered</title> <g> <path d="M8,19h13v-2H8V19z M8,13h13v-2H8V13z M8,5v2h13V5H8z M3.575,5.252c0.107-0.096,0.197-0.188,0.269-0.275
-		c-0.012,0.228-0.018,0.48-0.018,0.756V8h1.175V3.717H3.959L2.488,4.915l0.601,0.738L3.575,5.252z M3.909,13.016
-		c0.475-0.426,0.785-0.715,0.93-0.867c0.146-0.152,0.262-0.297,0.35-0.435c0.088-0.138,0.153-0.278,0.195-0.42
-		c0.042-0.143,0.063-0.298,0.063-0.466c0-0.225-0.06-0.427-0.18-0.608S4.978,9.9,4.76,9.803C4.542,9.704,4.295,9.655,4.018,9.655
-		c-0.221,0-0.419,0.022-0.596,0.067s-0.34,0.11-0.491,0.195c-0.15,0.085-0.336,0.226-0.557,0.423l0.636,0.744
-		c0.174-0.15,0.33-0.264,0.467-0.341c0.138-0.077,0.274-0.116,0.409-0.116c0.131,0,0.233,0.032,0.305,0.097
-		c0.072,0.064,0.108,0.152,0.108,0.264c0,0.09-0.018,0.176-0.054,0.258c-0.036,0.082-0.1,0.18-0.192,0.294
-		c-0.092,0.114-0.287,0.328-0.586,0.64l-1.046,1.058V14h3.108v-0.955h-1.62L3.909,13.016L3.909,13.016z M4.439,17.762v-0.018
-		c0.307-0.086,0.541-0.225,0.703-0.414c0.162-0.191,0.243-0.419,0.243-0.685c0-0.309-0.126-0.551-0.378-0.727
-		c-0.252-0.176-0.6-0.264-1.043-0.264c-0.307,0-0.579,0.033-0.816,0.1s-0.469,0.178-0.696,0.334l0.48,0.773
-		c0.293-0.184,0.576-0.275,0.85-0.275c0.147,0,0.263,0.027,0.35,0.082s0.13,0.139,0.13,0.252c0,0.301-0.294,0.451-0.882,0.451H3.11
-		v0.87h0.264c0.217,0,0.393,0.016,0.527,0.049c0.135,0.031,0.232,0.08,0.293,0.143c0.061,0.064,0.091,0.154,0.091,0.271
-		c0,0.152-0.058,0.264-0.174,0.336c-0.116,0.07-0.301,0.106-0.555,0.106c-0.164,0-0.343-0.022-0.538-0.069
-		c-0.194-0.045-0.385-0.116-0.573-0.212v0.961c0.228,0.088,0.441,0.148,0.637,0.182c0.196,0.033,0.41,0.05,0.64,0.05
-		c0.561,0,0.998-0.114,1.314-0.343c0.315-0.228,0.473-0.542,0.473-0.94C5.512,18.19,5.154,17.852,4.439,17.762z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-list-unordered"><title>gridicons-list-unordered</title> <g> <path d="M9,19h12v-2H9V19z M9,13h12v-2H9V13z M9,5v2h12V5H9z M5,4.5C4.172,4.5,3.5,5.172,3.5,6S4.172,7.5,5,7.5S6.5,6.828,6.5,6
-		S5.828,4.5,5,4.5z M5,10.5c-0.828,0-1.5,0.672-1.5,1.5s0.672,1.5,1.5,1.5s1.5-0.672,1.5-1.5S5.828,10.5,5,10.5z M5,16.5
-		c-0.828,0-1.5,0.672-1.5,1.5s0.672,1.5,1.5,1.5s1.5-0.672,1.5-1.5S5.828,16.5,5,16.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-location"><title>gridicons-location</title> <g> <path d="M19,9c0-3.866-3.134-7-7-7S5,5.134,5,9c0,1.387,0.409,2.677,1.105,3.765H6.097C8.458,16.459,12,22,12,22
-		s3.542-5.541,5.903-9.235h-0.007C18.591,11.677,19,10.387,19,9z M12,12c-1.657,0-3-1.343-3-3s1.343-3,3-3s3,1.343,3,3
-		S13.657,12,12,12z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-lock"><title>gridicons-lock</title> <g> <path d="M18,8h-1V7c0-2.757-2.243-5-5-5S7,4.243,7,7v1H6c-1.105,0-2,0.895-2,2v10c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V10
-		C20,8.895,19.105,8,18,8z M9,7c0-1.654,1.346-3,3-3s3,1.346,3,3v1H9V7z M13,15.723V18h-2v-2.277c-0.595-0.346-1-0.984-1-1.723
-		c0-1.105,0.895-2,2-2s2,0.895,2,2C14,14.738,13.595,15.376,13,15.723z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-mail"><title>gridicons-mail</title> <g> <path d="M20,4H4C2.895,4,2,4.895,2,6v12c0,1.105,0.895,2,2,2h16c1.105,0,2-0.895,2-2V6C22,4.895,21.105,4,20,4z M20,8.236l-8,4.882
-		L4,8.236V6h16V8.236z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-mention"><title>gridicons-mention</title><g><path d="M12,2a10,10,0,0,0,0,20V20a8,8,0,1,1,8-8v.5a1.5,1.5,0,0,1-3,0V7H15V8A5,5,0,1,0,16,15a3.5,3.5,0,0,0,6-2.46V12A10,10,0,0,0,12,2Zm0,13a3,3,0,1,1,3-3A3,3,0,0,1,12,15Z"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-menu"><title>gridicons-menu</title> <g> <path d="M21,6v2H3V6H21z M3,18h18v-2H3V18z M3,13h18v-2H3V13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-menus"><title>gridicons-menus</title> <g> <path d="M9,19h10v-2H9V19z M9,13h6v-2H9V13z M9,5v2h12V5H9z M5,4.5C4.172,4.5,3.5,5.172,3.5,6S4.172,7.5,5,7.5S6.5,6.828,6.5,6
-		S5.828,4.5,5,4.5z M5,10.5c-0.828,0-1.5,0.672-1.5,1.5s0.672,1.5,1.5,1.5s1.5-0.672,1.5-1.5S5.828,10.5,5,10.5z M5,16.5
-		c-0.828,0-1.5,0.672-1.5,1.5s0.672,1.5,1.5,1.5s1.5-0.672,1.5-1.5S5.828,16.5,5,16.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-microphone"><title>gridicons-microphone</title><g><path d="M19,9v1a7,7,0,0,1-6,6.92V20h3v2H8V20h3V16.92A7,7,0,0,1,5,10V9H7v1a5,5,0,0,0,10,0V9Zm-7,4a3,3,0,0,0,3-3V5A3,3,0,0,0,9,5v5A3,3,0,0,0,12,13Z"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-minus-small"><title>gridicons-minus-small</title> <g> <rect x="6" y="11" width="12" height="2"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-minus"><title>gridicons-minus</title> <g> <rect x="3" y="11" width="18" height="2"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-money"><title>gridicons-money</title> <g> <path d="M2,5v14h20V5H2z M7,17c0-1.657-1.343-3-3-3v-4c1.657,0,3-1.343,3-3h10c0,1.657,1.343,3,3,3v4c-1.657,0-3,1.343-3,3H7z
-		 M12,9c1.1,0,2,1.3,2,3s-0.9,3-2,3s-2-1.3-2-3S10.9,9,12,9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-my-sites-horizon"><title>gridicons-my-sites-horizon</title> <g> <path d="M10.986,13.928l0.762-2.284l-1.324-3.629C9.966,7.988,9.532,7.934,9.532,7.934C9.074,7.907,9.127,7.207,9.586,7.233
-		c0,0,1.403,0.108,2.239,0.108c0.889,0,2.266-0.108,2.266-0.108c0.458-0.027,0.512,0.646,0.054,0.701c0,0-0.461,0.054-0.973,0.081
-		l2.006,5.966c-0.875-0.035-1.74-0.054-2.599-0.061l-0.429-1.177l-0.403,1.171C11.495,13.915,11.239,13.924,10.986,13.928z
-		 M3.83,14.321C3.62,13.583,3.5,12.806,3.5,12c0-1.232,0.264-2.402,0.736-3.459l2.036,5.578c0.849-0.059,1.69-0.103,2.526-0.137
-		L6.792,8.015c0.512-0.027,0.973-0.081,0.973-0.081C8.223,7.88,8.169,7.207,7.71,7.233c0,0-1.376,0.108-2.265,0.108
-		c-0.16,0-0.347-0.004-0.547-0.01C6.418,5.024,9.03,3.5,12,3.5c2.213,0,4.228,0.846,5.74,2.232c-0.036-0.002-0.072-0.007-0.11-0.007
-		c-0.835,0-1.427,0.727-1.427,1.509c0,0.701,0.404,1.293,0.835,1.994c0.323,0.566,0.701,1.293,0.701,2.344
-		c0,0.674-0.245,1.463-0.573,2.51c0.301,0.019,0.604,0.043,0.907,0.066l0.798-2.307c0.485-1.213,0.646-2.182,0.646-3.044
-		c0-0.313-0.021-0.603-0.057-0.874C20.122,9.133,20.5,10.522,20.5,12c0,0.807-0.128,1.581-0.339,2.32
-		c0.5,0.049,1.005,0.112,1.508,0.169C21.875,13.692,22,12.862,22,12c0-5.523-4.477-10-10-10S2,6.477,2,12
-		c0,0.862,0.125,1.692,0.331,2.49C2.831,14.433,3.333,14.37,3.83,14.321z M18.468,17.488c-1.792,2.184-4.35,3.013-6.468,3.013
-		c-1.876,0-4.551-0.698-6.463-3.013c-0.585,0.048-1.174,0.1-1.769,0.161C5.571,20.271,8.578,22,12,22
-		c3.422,0,6.429-1.729,8.232-4.351C19.639,17.587,19.052,17.536,18.468,17.488z M12,15.01c-3.715,0-7.368,0.266-10.958,0.733
-		c0.179,0.41,0.35,0.825,0.506,1.247c3.427-0.431,6.91-0.679,10.452-0.679s7.025,0.248,10.452,0.679
-		c0.156-0.422,0.327-0.836,0.506-1.246C19.368,15.277,15.715,15.01,12,15.01z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-my-sites"><title>gridicons-my-sites</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10s10-4.477,10-10C22,6.477,17.523,2,12,2z M3.5,12
-		c0-1.232,0.264-2.402,0.736-3.459L8.291,19.65C5.455,18.272,3.5,15.365,3.5,12z M12,20.501c-0.834,0-1.64-0.122-2.401-0.346
-		l2.551-7.411l2.613,7.158c0.017,0.042,0.038,0.081,0.061,0.117C13.939,20.33,12.99,20.501,12,20.501z M13.172,8.015
-		c0.512-0.027,0.973-0.081,0.973-0.081c0.458-0.054,0.404-0.727-0.054-0.701c0,0-1.377,0.108-2.266,0.108
-		c-0.835,0-2.239-0.108-2.239-0.108C9.127,7.207,9.074,7.907,9.532,7.934c0,0,0.434,0.054,0.892,0.081l1.324,3.629l-1.86,5.579
-		L6.792,8.015c0.512-0.027,0.973-0.081,0.973-0.081C8.223,7.88,8.168,7.207,7.71,7.233c0,0-1.376,0.108-2.265,0.108
-		c-0.16,0-0.347-0.004-0.547-0.01C6.418,5.024,9.03,3.5,12,3.5c2.213,0,4.228,0.846,5.74,2.232c-0.037-0.002-0.072-0.007-0.11-0.007
-		c-0.835,0-1.427,0.727-1.427,1.509c0,0.701,0.404,1.293,0.835,1.994c0.323,0.566,0.701,1.293,0.701,2.344
-		c0,0.727-0.28,1.572-0.647,2.748l-0.848,2.833L13.172,8.015z M16.273,19.347l2.596-7.506c0.485-1.213,0.646-2.182,0.646-3.045
-		c0-0.313-0.021-0.603-0.057-0.874C20.122,9.133,20.5,10.522,20.5,12C20.5,15.136,18.801,17.874,16.273,19.347z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-not-visible"><title>gridicons-not-visible</title> <g> <path d="M1,12c0,0,4.188-6,11-6c0.947,0,1.839,0.121,2.678,0.322L8.36,12.64C8.133,12.139,8,11.586,8,11
-		c0-0.937,0.335-1.787,0.875-2.469C6.483,9.343,4.661,10.916,3.621,12c0.678,0.707,1.695,1.621,2.98,2.398l-1.453,1.453
-		C2.497,14.13,1,12,1,12z M23,12c0,0-4.188,6-11,6c-0.946,0-1.836-0.124-2.676-0.323L5,22l-1.5-1.5l17-17L22,5l-3.147,3.147
-		C21.501,9.869,23,12,23,12z M20.385,12.006c-0.678-0.708-1.697-1.624-2.987-2.403L16,11c0,2.209-1.791,4-4,4l-0.947,0.947
-		C11.363,15.978,11.677,16,12,16C15.978,16,18.943,13.522,20.385,12.006z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-notice-outline"><title>gridicons-notice-outline</title> <g> <path d="M12,4c4.411,0,8,3.589,8,8s-3.589,8-8,8s-8-3.589-8-8S7.589,4,12,4 M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10
-		s10-4.477,10-10S17.523,2,12,2L12,2z M13,15h-2v2h2V15z M11,13h2l0.5-6h-3L11,13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-notice"><title>gridicons-notice</title> <g> <g> <path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10s10-4.477,10-10C22,6.477,17.523,2,12,2z M13,17h-2v-2h2V17z M13,13h-2
-			l-0.5-6h3L13,13z"/> </g> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-offline"><title>gridicons-offline</title><g><polygon points="10 3 18 3 14 9 18 9 6 21 10 12 6 12 10 3"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-pages"><title>gridicons-pages</title> <g> <path d="M16,8H8V6h8V8z M16,10H8v2h8V10z M20,4v12l-6,6H6c-1.105,0-2-0.895-2-2V4c0-1.105,0.895-2,2-2h12C19.105,2,20,2.895,20,4z
-		 M18,14V4H6v16h6v-4c0-1.105,0.895-2,2-2H18z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-pause"><title>gridicons-pause</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10s10-4.477,10-10S17.523,2,12,2z M11,16H9V8h2V16z M15,16h-2V8h2V16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-pencil"><title>gridicons-pencil</title> <g> <path d="M13,6l5,5l-9.507,9.507c-0.686-0.686-0.689-1.794-0.012-2.485l-0.003-0.003c-0.691,0.677-1.799,0.674-2.485-0.012
-		c-0.677-0.677-0.686-1.762-0.036-2.455l-0.008-0.008c-0.693,0.649-1.779,0.64-2.455-0.036L13,6z M20.586,5.586l-2.172-2.172
-		c-0.781-0.781-2.047-0.781-2.828,0L14,5l5,5l1.586-1.586C21.367,7.633,21.367,6.367,20.586,5.586z M3,18v3h3
-		C6,19.343,4.657,18,3,18z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-phone"><title>gridicons-phone</title> <g> <path d="M16,2H8C6.896,2,6,2.896,6,4v16c0,1.104,0.896,2,2,2h8c1.104,0,2-0.896,2-2V4C18,2.896,17.104,2,16,2z M13,21h-2v-1h2V21z
-		 M16,19H8V5h8V19z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-plugins"><title>gridicons-plugins</title> <g> <path d="M16,8V3c0-0.552-0.448-1-1-1s-1,0.448-1,1v5h-4V3c0-0.552-0.448-1-1-1S8,2.448,8,3v5H5v4c0,2.791,1.637,5.193,4,6.317V22h6
-		v-3.683c2.363-1.124,4-3.527,4-6.317V8H16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-plus-small"><title>gridicons-plus-small</title> <g> <polygon points="18,11 13,11 13,6 11,6 11,11 6,11 6,13 11,13 11,18 13,18 13,13 18,13 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-plus"><title>gridicons-plus</title><g><path d="M21,13H13v8H11V13H3V11h8V3h2v8h8v2Z"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-popout"><title>gridicons-popout</title> <path d="M6,7V5c0-1.105,0.895-2,2-2h11c1.105,0,2,0.895,2,2v14c0,1.105-0.895,2-2,2H8c-1.105,0-2-0.895-2-2v-2h2v2h11V5H8v2H6z
-	 M11.5,6.5l-1.414,1.414L13.172,11H3v2h10.172l-3.086,3.086L11.5,17.5L17,12L11.5,6.5z"/> </symbol><symbol viewBox="0 0 24 24" id="gridicons-posts"><title>gridicons-posts</title> <g> <path d="M16,19H3v-2h13V19z M21,9H3v2h18V9z M3,5v2h11V5H3z M17,5v2h4V5H17z M11,13v2h10v-2H11z M3,13v2h5v-2H3z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-print"><title>gridicons-print</title> <g> <path d="M9,16h6v2H9V16z M22,17h-3v3c0,1.105-0.895,2-2,2H7c-1.105,0-2-0.895-2-2v-3H2V9c0-1.105,0.895-2,2-2h1V5
-		c0-1.105,0.895-2,2-2h10c1.105,0,2,0.895,2,2v2h1c1.105,0,2,0.895,2,2V17z M7,7h10V5H7V7z M17,14H7v6h10V14z M20,10.5
-		C20,9.672,19.328,9,18.5,9S17,9.672,17,10.5s0.672,1.5,1.5,1.5S20,11.328,20,10.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-product-downloadable"><title>gridicons-product-downloadable</title> <g> <path d="M22,3H2v6h1v11c0,1.105,0.895,2,2,2h14c1.105,0,2-0.895,2-2V9h1V3z M4,5h16v2H4V5z M19,20H5V9h14V20z M13,10v5.17
-		l2.59-2.58L17,14l-5,5l-5-5l1.41-1.42L11,15.17V10H13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-product-external"><title>gridicons-product-external</title> <g> <path d="M22,3H2v6h1v11c0,1.105,0.895,2,2,2h14c1.105,0,2-0.895,2-2V9h1V3z M4,5h16v2H4V5z M19,20H5V9h14V20z M17,11v6h-2v-2.59
-		l-3.29,3.29l-1.41-1.41L13.59,13H11v-2H17z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-product-virtual"><title>gridicons-product-virtual</title> <g> <path d="M22,3H2v6h1v11c0,1.105,0.895,2,2,2h14c1.105,0,2-0.895,2-2V9h1V3z M4,5h16v2H4V5z M19,20H5V9h14V20z M7,16.45
-		c0-1.005,0.815-1.82,1.82-1.82h0.09c-0.335-1.589,0.681-3.148,2.27-3.483s3.148,0.681,3.483,2.27
-		c0.02,0.097,0.036,0.195,0.046,0.293l0,0c1.253-0.025,2.29,0.971,2.315,2.224c0.017,0.868-0.462,1.67-1.235,2.066H7.87
-		C7.329,17.671,6.999,17.083,7,16.45z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-product"><title>gridicons-product</title> <g> <path d="M22,3H2v6h1v11c0,1.105,0.895,2,2,2h14c1.105,0,2-0.895,2-2V9h1V3z M4,5h16v2H4V5z M19,20H5V9h14V20z M9,11h6
-		c0,1.105-0.895,2-2,2h-2C9.895,13,9,12.105,9,11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-quote"><title>gridicons-quote</title> <g> <path d="M11.192,15.757c0-0.88-0.23-1.618-0.69-2.217c-0.326-0.412-0.768-0.683-1.327-0.812c-0.55-0.128-1.07-0.137-1.54-0.028
-		c-0.16-0.95,0.1-1.956,0.76-3.022c0.66-1.065,1.515-1.867,2.558-2.403L9.372,5c-0.8,0.396-1.56,0.898-2.26,1.505
-		c-0.71,0.607-1.34,1.305-1.9,2.094s-0.98,1.68-1.25,2.69s-0.345,2.04-0.216,3.1c0.168,1.4,0.62,2.52,1.356,3.35
-		C5.837,18.58,6.754,19,7.85,19c0.965,0,1.766-0.29,2.4-0.878c0.628-0.576,0.94-1.365,0.94-2.368L11.192,15.757z M20.316,15.757
-		c0-0.88-0.23-1.618-0.69-2.217c-0.326-0.42-0.77-0.692-1.327-0.817c-0.56-0.124-1.073-0.13-1.54-0.022
-		c-0.16-0.94,0.09-1.95,0.752-3.02c0.66-1.06,1.513-1.86,2.556-2.4L18.49,5c-0.8,0.396-1.555,0.898-2.26,1.505
-		c-0.708,0.607-1.34,1.305-1.894,2.094c-0.556,0.79-0.97,1.68-1.24,2.69c-0.273,1.002-0.345,2.04-0.217,3.1
-		c0.166,1.4,0.616,2.52,1.35,3.35c0.733,0.834,1.647,1.252,2.743,1.252c0.967,0,1.768-0.29,2.402-0.877
-		c0.627-0.576,0.942-1.365,0.942-2.368L20.316,15.757z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-read-more"><title>gridicons-read-more</title> <path d="M3,5h18v4H3V5z M3,19h18v-4H3V19z M9,13h6v-2H9V13z M3,13h4v-2H3V13z M17,13h4v-2h-4V13z"/> </symbol><symbol viewBox="0 0 24 24" id="gridicons-reader-follow"><title>gridicons-reader-follow</title> <g> <path d="M23,16v2h-3v3h-2v-3h-3v-2h3v-3h2v3H23z M20,2v9h-4v3h-3v4H4c-1.1,0-2-0.9-2-2V2H20z M8,13v-1H4v1H8z M11,10H4v1h7V10z
-		 M11,8H4v1h7V8z M18,4H4v2h14V4z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-reader-following"><title>gridicons-reader-following</title> <g> <path d="M23,13.482L15.508,21L12,17.4l1.412-1.388l2.106,2.188l6.094-6.094L23,13.482z M15.545,15.344L20,10.889V2H2v14
-		c0,1.1,0.9,2,2,2h4.538l4.913-4.832L15.545,15.344z M8,13H4v-1h4V13z M11,11H4v-1h7V11z M11,9H4V8h7V9z M18,6H4V4h14V6z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-reader"><title>gridicons-reader</title> <g> <path d="M3,4v14c0,1.1,0.9,2,2,2h14c1.1,0,2-0.9,2-2V4H3z M10,15H5v-1h5V15z M12,13H5v-1h7V13z M12,11H5v-1h7V11z M19,15h-5v-5h5
-		V15z M19,8H5V6h14V8z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-reblog"><title>gridicons-reblog</title> <g> <path d="M22.086,9.914L20,7.828V18c0,1.105-0.895,2-2,2h-7v-2h7V7.828l-2.086,2.086L14.5,8.5L19,4l4.5,4.5L22.086,9.914z M6,16.172
-		V6h7V4H6C4.895,4,4,4.895,4,6v10.172l-2.086-2.086L0.5,15.5L5,20l4.5-4.5l-1.414-1.414L6,16.172z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-redo"><title>gridicons-redo</title> <g> <path d="M18,6v3.586l-3.657-3.657c-1.172-1.172-2.707-1.757-4.243-1.757S7.029,4.757,5.858,5.929c-2.343,2.343-2.343,6.142,0,8.485
-		l5.364,5.364l1.414-1.414L7.272,13c-1.56-1.56-1.56-4.097,0-5.657c0.755-0.755,1.76-1.172,2.828-1.172
-		c1.068,0,2.073,0.416,2.828,1.172L16.586,11H13v2h7V6H18z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-refresh"><title>gridicons-refresh</title> <g> <path d="M17.91,14c-0.478,2.833-2.943,5-5.91,5c-3.308,0-6-2.692-6-6s2.692-6,6-6h2.172l-2.086,2.086L13.5,10.5L18,6l-4.5-4.5
-		l-1.414,1.414L14.172,5H12c-4.418,0-8,3.582-8,8s3.582,8,8,8c4.079,0,7.438-3.055,7.931-7H17.91z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-refund"><title>gridicons-refund</title> <g> <path d="M13.91,2.91L11.83,5H14c4.418,0,8,3.582,8,8h-2c0-3.314-2.686-6-6-6h-2.17l2.09,2.09L12.5,10.5L8,6l1.41-1.41L12.5,1.5
-		L13.91,2.91z M2,12v10h16V12H2z M4,18.56v-3.11c0.601-0.349,1.101-0.849,1.45-1.45h9.1c0.349,0.601,0.849,1.101,1.45,1.45v3.11
-		c-0.593,0.349-1.085,0.845-1.43,1.44H5.45C5.1,19.403,4.6,18.906,4,18.56z M10,19c0.828,0,1.5-0.895,1.5-2s-0.672-2-1.5-2
-		s-1.5,0.895-1.5,2S9.172,19,10,19z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-reply"><title>gridicons-reply</title> <g> <path d="M14,8H6.828l2.586-2.586L8,4L3,9l5,5l1.414-1.414L6.828,10H14c2.206,0,4,1.794,4,4s-1.794,4-4,4h-2v2h2
-		c3.314,0,6-2.686,6-6S17.314,8,14,8z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-resize"><title>gridicons-resize</title><g><polygon points="13 4 13 6 16.59 6 6 16.59 6 13 4 13 4 20 11 20 11 18 7.41 18 18 7.41 18 11 20 11 20 4 13 4"/></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-rotate"><title>gridicons-rotate</title> <g> <path d="M18,14v6c0,1.105-0.895,2-2,2H6c-1.105,0-2-0.895-2-2v-6c0-1.105,0.895-2,2-2h10C17.105,12,18,12.895,18,14z M13.914,2.914
-		L11.828,5H14c4.418,0,8,3.582,8,8h-2c0-3.308-2.692-6-6-6h-2.172l2.086,2.086L12.5,10.5L8,6l1.414-1.414L12.5,1.5L13.914,2.914z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-scheduled"><title>gridicons-scheduled</title> <g> <path d="M10.498,18.001l-3.705-3.705l1.415-1.415l2.294,2.294l5.293-5.293l1.415,1.415L10.498,18.001z M21,6v13
-		c0,1.104-0.896,2-2,2H5c-1.104,0-2-0.896-2-2V6c0-1.104,0.896-2,2-2h1V2h2v2h8V2h2v2h1C20.104,4,21,4.896,21,6z M19,8H5v11h14V8z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-search"><title>gridicons-search</title> <g> <path d="M21,19l-5.154-5.154C16.574,12.742,17,11.421,17,10c0-3.866-3.134-7-7-7s-7,3.134-7,7c0,3.866,3.134,7,7,7
-		c1.421,0,2.742-0.426,3.846-1.154L19,21L21,19z M5,10c0-2.757,2.243-5,5-5s5,2.243,5,5s-2.243,5-5,5S5,12.757,5,10z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-share-ios"><title>gridicons-share-ios</title> <g> <path d="M17,8h2c1.105,0,2,0.895,2,2v9c0,1.105-0.895,2-2,2H5c-1.105,0-2-0.895-2-2v-9c0-1.105,0.895-2,2-2h2v2H5v9h14v-9h-2V8z
-		 M6.5,5.5l1.414,1.414L11,3.828V14h2V3.828l3.086,3.086L17.5,5.5L12,0L6.5,5.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-share"><title>gridicons-share</title> <g> <path d="M18,16c-0.788,0-1.499,0.31-2.034,0.807L8.91,12.7C8.96,12.47,9,12.24,9,12s-0.04-0.47-0.09-0.7l7.05-4.11
-		C16.5,7.69,17.21,8,18,8c1.66,0,3-1.34,3-3c0-1.66-1.34-3-3-3s-3,1.34-3,3c0,0.24,0.04,0.47,0.09,0.7L8.04,9.81
-		C7.5,9.31,6.79,9,6,9c-1.66,0-3,1.34-3,3c0,1.66,1.34,3,3,3c0.79,0,1.5-0.31,2.04-0.81l7.048,4.118C15.035,18.531,15,18.761,15,19
-		c0,1.657,1.343,3,3,3s3-1.343,3-3S19.657,16,18,16z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-shipping"><title>gridicons-shipping</title> <g> <path d="M18,8h-2V7c0-1.105-0.895-2-2-2H4C2.895,5,2,5.895,2,7v10h2c0,1.657,1.343,3,3,3s3-1.343,3-3h4c0,1.657,1.343,3,3,3
-		s3-1.343,3-3h2v-5L18,8z M7,18.5c-0.828,0-1.5-0.672-1.5-1.5s0.672-1.5,1.5-1.5s1.5,0.672,1.5,1.5S7.828,18.5,7,18.5z M4,14V7h10v7
-		H4z M17,18.5c-0.828,0-1.5-0.672-1.5-1.5s0.672-1.5,1.5-1.5s1.5,0.672,1.5,1.5S17.828,18.5,17,18.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-sign-out"><title>gridicons-sign-out</title> <g> <path d="M16,17v2c0,1.105-0.895,2-2,2H5c-1.105,0-2-0.895-2-2V5c0-1.105,0.895-2,2-2h9c1.105,0,2,0.895,2,2v2h-2V5H5v14h9v-2H16z
-		 M18.5,6.5l-1.414,1.414L20.172,11H10v2h10.172l-3.086,3.086L18.5,17.5L24,12L18.5,6.5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-spam"><title>gridicons-spam</title> <g> <path d="M17,2H7L2,7v10l5,5h10l5-5V7L17,2z M13,17h-2v-2h2V17z M13,13h-2l-0.5-6h3L13,13z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-speaker"><title>gridicons-speaker</title> <g> <g> <path d="M19,8v3v3c1.7,0,3-1.3,3-3S20.7,8,19,8z"/> <g> <path d="M11,7H4C2.9,7,2,7.9,2,9v4c0,1.1,0.9,2,2,2h1v3c0,1.1,0.9,2,2,2h2v-3v-2h2l4,4h2V3h-2L11,7z"/> </g> </g> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-special-character"><title>gridicons-special-character</title> <g> <path d="M12.005,7.418c-1.237,0-2.191,0.376-2.861,1.128S8.14,10.358,8.14,11.725c0,1.388,0.226,2.514,0.677,3.378
-		c0.451,0.865,1.135,1.543,2.051,2.036V20H5v-2.666h3.119c-1.039-0.636-1.841-1.502-2.404-2.6c-0.564-1.097-0.846-2.322-0.846-3.676
-		c0-1.258,0.292-2.363,0.876-3.317C6.33,6.788,7.162,6.055,8.242,5.542s2.334-0.769,3.763-0.769c2.181,0,3.915,0.571,5.204,1.712
-		s1.933,2.673,1.933,4.594c0,1.354-0.283,2.57-0.852,3.65c-0.567,1.08-1.38,1.948-2.44,2.604H19V20h-5.908v-2.861
-		c0.95-0.492,1.651-1.179,2.102-2.061s0.677-2.006,0.677-3.374c0-1.36-0.337-2.415-1.01-3.164
-		C14.188,7.793,13.236,7.418,12.005,7.418z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-star-outline"><title>gridicons-star-outline</title> <g> <path d="M12,6.308l1.176,3.167l0.347,0.936l0.997,0.041l3.374,0.139l-2.647,2.092l-0.784,0.62l0.27,0.962l0.911,3.249l-2.814-1.871
-		L12,15.09l-0.83,0.552l-2.814,1.871l0.911-3.249l0.27-0.962l-0.784-0.62L6.105,10.59l3.374-0.139l0.997-0.041l0.347-0.936L12,6.308
-		 M12,2L9.418,8.953L2,9.257l5.822,4.602L5.82,21L12,16.891L18.18,21l-2.002-7.141L22,9.257l-7.418-0.305L12,2L12,2z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-star"><title>gridicons-star</title> <g> <polygon points="12,2 14.582,8.953 22,9.257 16.178,13.859 18.18,21 12,16.891 5.82,21 7.822,13.859 2,9.257 9.418,8.953 	"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-stats-alt"><title>gridicons-stats-alt</title> <g> <path d="M21,21H3v-2h18V21z M8,10H4v7h4V10z M14,3h-4v14h4V3z M20,6h-4v11h4V6z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-stats"><title>gridicons-stats</title> <g> <path d="M19,3H5C3.895,3,3,3.895,3,5v14c0,1.105,0.895,2,2,2h14c1.105,0,2-0.895,2-2V5C21,3.895,20.105,3,19,3z M19,19H5V5h14V19z
-		 M9,17H7v-5h2V17z M13,17h-2V7h2V17z M17,17h-2v-7h2V17z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-status"><title>gridicons-status</title> <g> <path d="M12,4c4.411,0,8,3.589,8,8s-3.589,8-8,8s-8-3.589-8-8S7.589,4,12,4 M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10
-		s10-4.477,10-10S17.523,2,12,2L12,2z M7.55,13c-0.019,0.166-0.05,0.329-0.05,0.5c0,2.485,2.015,4.5,4.5,4.5s4.5-2.015,4.5-4.5
-		c0-0.171-0.032-0.334-0.05-0.5H7.55z M10,10V8c0-0.552-0.448-1-1-1l0,0C8.448,7,8,7.448,8,8v2c0,0.552,0.448,1,1,1l0,0
-		C9.552,11,10,10.552,10,10z M16,10V8c0-0.552-0.448-1-1-1l0,0c-0.552,0-1,0.448-1,1v2c0,0.552,0.448,1,1,1l0,0
-		C15.552,11,16,10.552,16,10z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-strikethrough"><title>gridicons-strikethrough</title> <g> <path d="M14.348,12H21v2h-4.613c0.239,0.515,0.368,1.094,0.368,1.748c0,1.317-0.474,2.355-1.423,3.114
-		C14.385,19.621,13.066,20,11.376,20c-1.557,0-2.934-0.293-4.132-0.878v-2.874c0.985,0.439,1.818,0.749,2.5,0.928
-		c0.682,0.181,1.306,0.27,1.872,0.27c0.679,0,1.2-0.129,1.562-0.39c0.363-0.259,0.545-0.644,0.545-1.158
-		c0-0.285-0.08-0.54-0.24-0.763c-0.16-0.222-0.394-0.437-0.704-0.643c-0.18-0.12-0.482-0.287-0.88-0.491H3v-2h5.597H14.348z
-		 M10.82,10c-0.073-0.077-0.143-0.155-0.193-0.235c-0.126-0.202-0.189-0.441-0.189-0.713c0-0.439,0.156-0.795,0.469-1.068
-		c0.313-0.273,0.762-0.409,1.348-0.409c0.492,0,0.993,0.063,1.502,0.19c0.509,0.126,1.153,0.349,1.931,0.669l0.998-2.405
-		c-0.752-0.326-1.472-0.579-2.16-0.758C13.836,5.09,13.113,5,12.354,5C10.81,5,9.601,5.369,8.726,6.108
-		C7.852,6.846,7.414,7.861,7.414,9.152c0,0.302,0.036,0.58,0.088,0.848H10.82z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-sync"><title>gridicons-sync</title> <g> <path d="M23.5,13.5l-3.086,3.086L19,18l-4.5-4.5l1.414-1.414L18,14.172V12c0-3.308-2.692-6-6-6V4c4.418,0,8,3.582,8,8v2.172
-		l2.086-2.086L23.5,13.5z M6,12V9.828l2.086,2.086L9.5,10.5L5,6L3.586,7.414L0.5,10.5l1.414,1.414L4,9.828V12c0,4.418,3.582,8,8,8
-		v-2C8.692,18,6,15.308,6,12z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-tablet"><title>gridicons-tablet</title> <g> <path d="M18,2H6C4.896,2,4,2.896,4,4v16c0,1.104,0.896,2,2,2h12c1.104,0,2-0.896,2-2V4C20,2.896,19.104,2,18,2z M13,21h-2v-1h2V21z
-		 M18,19H6V5h12V19z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-tag"><title>gridicons-tag</title> <g> <path d="M20,2.007h-7.087c-0.53,0-1.039,0.211-1.414,0.586l-8.906,8.906c-0.781,0.781-0.781,2.047,0,2.828l7.086,7.086
-		c0.781,0.781,2.047,0.781,2.828,0l8.906-8.906C21.789,12.133,22,11.624,22,11.094V4.007C22,2.902,21.105,2.007,20,2.007z M17.007,9
-		c-1.105,0-2-0.895-2-2c0-1.105,0.895-2,2-2s2,0.895,2,2C19.007,8.105,18.112,9,17.007,9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-text-color"><title>gridicons-text-color</title> <g> <g> <path d="M3,19h18v3H3V19z"/> <path d="M15.82,17h3.424L14,3h-4L4.756,17h3.425l1.066-3.5h5.506L15.82,17z M13.868,11h-3.73l1.868-5.725L13.868,11z"/> </g> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-themes"><title>gridicons-themes</title> <g> <path d="M4,6L4,6C2.895,6,2,6.895,2,8v12c0,1.1,0.9,2,2,2h12c1.105,0,2-0.895,2-2v0H4V6z M20,2H8C6.895,2,6,2.895,6,4v12
-		c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V4C22,2.895,21.105,2,20,2z M15,16H8V9h7V16z M20,16h-3V9h3V16z M20,7H8V4h12V7z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-thumbs-up"><title>gridicons-thumbs-up</title> <g> <path d="M6.7,22H2v-9h2L6.7,22z M19.999,9H14V5c0-1.657-1.343-3-3-3h-1v4L7.1,9.625C6.388,10.515,6,11.621,6,12.76V14l2.1,7h8.337
-		c1.836,0,3.435-1.249,3.881-3.03l1.621-6.485C22.255,10.223,21.3,9,19.999,9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-time"><title>gridicons-time</title> <g> <path d="M12,4c4.411,0,8,3.589,8,8s-3.589,8-8,8s-8-3.589-8-8S7.589,4,12,4 M12,2C6.477,2,2,6.477,2,12s4.477,10,10,10
-		s10-4.477,10-10S17.523,2,12,2L12,2z M15.8,15.4L13,11.667V7h-2v5.333l3.2,4.266L15.8,15.4z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-trash"><title>gridicons-trash</title> <g> <path d="M6.187,8h11.625l-0.695,11.125C17.051,20.179,16.177,21,15.121,21H8.879c-1.056,0-1.93-0.821-1.996-1.875L6.187,8z M19,5v2
-		H5V5h3V4c0-1.105,0.895-2,2-2h4c1.105,0,2,0.895,2,2v1H19z M10,5h4V4h-4V5z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-trophy"><title>gridicons-trophy</title> <g> <path d="M18,5.062V3H6v2.062H2V8c0,2.525,1.889,4.598,4.324,4.932C7.024,14.99,8.809,16.542,11,16.91V18c0,1.105-0.895,2-2,2H8v2h1
-		h2h2h2h1v-2h-1c-1.105,0-2-0.895-2-2v-1.09c2.191-0.368,3.976-1.92,4.676-3.978C20.111,12.598,22,10.525,22,8V5.062H18z M4,8V7.062
-		h2v3.766C4.836,10.416,4,9.304,4,8z M20,8c0,1.304-0.836,2.416-2,2.829V7.062h2V8z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-types"><title>gridicons-types</title> <g> <path d="M22,17c0,2.761-2.239,5-5,5s-5-2.239-5-5s2.239-5,5-5S22,14.239,22,17z M6.5,6.5h3.8L7,1L1,11h5.5V6.5z M16,10.585V8H8v8
-		h2.585C11.018,13.217,13.217,11.018,16,10.585z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-underline"><title>gridicons-underline</title> <g> <path d="M4,19v2h16v-2H4z M18,3v8c0,3.314-2.686,6-6,6s-6-2.686-6-6V3h3v8c0,1.654,1.346,3,3,3c1.654,0,3-1.346,3-3V3H18z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-undo"><title>gridicons-undo</title> <g> <path d="M18.142,5.929c-1.172-1.172-2.707-1.757-4.243-1.757s-3.071,0.586-4.243,1.757L6,9.586V6H4v7h7v-2H7.414l3.657-3.657
-		c0.755-0.755,1.76-1.172,2.828-1.172c1.068,0,2.073,0.416,2.828,1.172c1.56,1.56,1.56,4.097,0,5.657l-5.364,5.364l1.414,1.414
-		l5.364-5.364C20.485,12.071,20.485,8.272,18.142,5.929z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-user-add"><title>gridicons-user-add</title><g><g data-name="Artwork"><g data-name="Artwork"><circle cx="15" cy="8" r="4"/><path d="M15,20s8,0,8-2c0-2.4-3.9-5-8-5s-8,2.6-8,5C7,20,15,20,15,20Z"/></g><path d="M6,10V7H4v3H1v2H4v3H6V12H9V10Z"/></g></g></symbol><symbol viewBox="0 0 24 24" id="gridicons-user-circle"><title>gridicons-user-circle</title> <g> <path d="M12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10s10-4.477,10-10C22,6.477,17.523,2,12,2z M12,20.5
-		c-4.694,0-8.5-3.806-8.5-8.5c0-4.694,3.806-8.5,8.5-8.5s8.5,3.806,8.5,8.5C20.5,16.694,16.694,20.5,12,20.5z M12,12.5
-		c-3.038,0-5.5,1.728-5.5,3.5s2.462,3.5,5.5,3.5s5.5-1.728,5.5-3.5S15.038,12.5,12,12.5z M12,12c1.657,0,3-1.343,3-3
-		c0-1.657-1.343-3-3-3S9,7.343,9,9C9,10.657,10.343,12,12,12z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-user"><title>gridicons-user</title> <g> <path d="M12,4c2.209,0,4,1.791,4,4s-1.791,4-4,4c-2.209,0-4-1.791-4-4S9.791,4,12,4z M12,20c0,0,8,0,8-2c0-2.4-3.9-5-8-5
-		s-8,2.6-8,5C4,20,12,20,12,20z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-video-camera"><title>gridicons-video-camera</title> <g> <path d="M17,9V7c0-1.105-0.895-2-2-2H4C2.895,5,2,5.895,2,7v10c0,1.105,0.895,2,2,2h11c1.105,0,2-0.895,2-2v-2l5,4V5L17,9z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-video"><title>gridicons-video</title> <g> <path d="M20,4v2h-2V4H6v2H4V4C2.895,4,2,4.895,2,6v12c0,1.105,0.895,2,2,2v-2h2v2h12v-2h2v2c1.105,0,2-0.895,2-2V6
-		C22,4.895,21.105,4,20,4z M6,16H4v-3h2V16z M6,11H4V8h2V11z M10,15V9l4.5,3L10,15z M20,16h-2v-3h2V16z M20,11h-2V8h2V11z"/> </g>  </symbol><symbol viewBox="0 0 24 24" id="gridicons-visible"><title>gridicons-visible</title> <g> <path d="M12,6C5.188,6,1,12,1,12s4.188,6,11,6s11-6,11-6S18.812,6,12,6z M12,16c-3.943,0-6.926-2.484-8.379-4
-		c1.04-1.085,2.862-2.657,5.254-3.469C8.335,9.213,8,10.063,8,11c0,2.209,1.791,4,4,4s4-1.791,4-4c0-0.937-0.335-1.787-0.875-2.469
-		c2.393,0.812,4.216,2.385,5.254,3.469C18.924,13.518,15.942,16,12,16z"/> </g>  </symbol></svg>
-
 <div class="icons">
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-add-image">
-		<use xlink:href="#gridicons-add-image" />
+		<use xlink:href="gridicons.svg#gridicons-add-image" />
 		</svg>
 		<p>gridicons-add-image</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-add-outline">
-		<use xlink:href="#gridicons-add-outline" />
+		<use xlink:href="gridicons.svg#gridicons-add-outline" />
 		</svg>
 		<p>gridicons-add-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-add">
-		<use xlink:href="#gridicons-add" />
+		<use xlink:href="gridicons.svg#gridicons-add" />
 		</svg>
 		<p>gridicons-add</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-center">
-		<use xlink:href="#gridicons-align-center" />
+		<use xlink:href="gridicons.svg#gridicons-align-center" />
 		</svg>
 		<p>gridicons-align-center</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-image-center">
-		<use xlink:href="#gridicons-align-image-center" />
+		<use xlink:href="gridicons.svg#gridicons-align-image-center" />
 		</svg>
 		<p>gridicons-align-image-center</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-image-left">
-		<use xlink:href="#gridicons-align-image-left" />
+		<use xlink:href="gridicons.svg#gridicons-align-image-left" />
 		</svg>
 		<p>gridicons-align-image-left</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-image-none">
-		<use xlink:href="#gridicons-align-image-none" />
+		<use xlink:href="gridicons.svg#gridicons-align-image-none" />
 		</svg>
 		<p>gridicons-align-image-none</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-image-right">
-		<use xlink:href="#gridicons-align-image-right" />
+		<use xlink:href="gridicons.svg#gridicons-align-image-right" />
 		</svg>
 		<p>gridicons-align-image-right</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-justify">
-		<use xlink:href="#gridicons-align-justify" />
+		<use xlink:href="gridicons.svg#gridicons-align-justify" />
 		</svg>
 		<p>gridicons-align-justify</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-left">
-		<use xlink:href="#gridicons-align-left" />
+		<use xlink:href="gridicons.svg#gridicons-align-left" />
 		</svg>
 		<p>gridicons-align-left</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-align-right">
-		<use xlink:href="#gridicons-align-right" />
+		<use xlink:href="gridicons.svg#gridicons-align-right" />
 		</svg>
 		<p>gridicons-align-right</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-arrow-down">
-		<use xlink:href="#gridicons-arrow-down" />
+		<use xlink:href="gridicons.svg#gridicons-arrow-down" />
 		</svg>
 		<p>gridicons-arrow-down</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-arrow-left">
-		<use xlink:href="#gridicons-arrow-left" />
+		<use xlink:href="gridicons.svg#gridicons-arrow-left" />
 		</svg>
 		<p>gridicons-arrow-left</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-arrow-right">
-		<use xlink:href="#gridicons-arrow-right" />
+		<use xlink:href="gridicons.svg#gridicons-arrow-right" />
 		</svg>
 		<p>gridicons-arrow-right</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-arrow-up">
-		<use xlink:href="#gridicons-arrow-up" />
+		<use xlink:href="gridicons.svg#gridicons-arrow-up" />
 		</svg>
 		<p>gridicons-arrow-up</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-aside">
-		<use xlink:href="#gridicons-aside" />
+		<use xlink:href="gridicons.svg#gridicons-aside" />
 		</svg>
 		<p>gridicons-aside</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-attachment">
-		<use xlink:href="#gridicons-attachment" />
+		<use xlink:href="gridicons.svg#gridicons-attachment" />
 		</svg>
 		<p>gridicons-attachment</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-audio">
-		<use xlink:href="#gridicons-audio" />
+		<use xlink:href="gridicons.svg#gridicons-audio" />
 		</svg>
 		<p>gridicons-audio</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-bell">
-		<use xlink:href="#gridicons-bell" />
+		<use xlink:href="gridicons.svg#gridicons-bell" />
 		</svg>
 		<p>gridicons-bell</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-block">
-		<use xlink:href="#gridicons-block" />
+		<use xlink:href="gridicons.svg#gridicons-block" />
 		</svg>
 		<p>gridicons-block</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-bold">
-		<use xlink:href="#gridicons-bold" />
+		<use xlink:href="gridicons.svg#gridicons-bold" />
 		</svg>
 		<p>gridicons-bold</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-book">
-		<use xlink:href="#gridicons-book" />
+		<use xlink:href="gridicons.svg#gridicons-book" />
 		</svg>
 		<p>gridicons-book</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-bookmark-outline">
-		<use xlink:href="#gridicons-bookmark-outline" />
+		<use xlink:href="gridicons.svg#gridicons-bookmark-outline" />
 		</svg>
 		<p>gridicons-bookmark-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-bookmark">
-		<use xlink:href="#gridicons-bookmark" />
+		<use xlink:href="gridicons.svg#gridicons-bookmark" />
 		</svg>
 		<p>gridicons-bookmark</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-briefcase">
-		<use xlink:href="#gridicons-briefcase" />
+		<use xlink:href="gridicons.svg#gridicons-briefcase" />
 		</svg>
 		<p>gridicons-briefcase</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-calendar">
-		<use xlink:href="#gridicons-calendar" />
+		<use xlink:href="gridicons.svg#gridicons-calendar" />
 		</svg>
 		<p>gridicons-calendar</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-camera">
-		<use xlink:href="#gridicons-camera" />
+		<use xlink:href="gridicons.svg#gridicons-camera" />
 		</svg>
 		<p>gridicons-camera</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-caption">
-		<use xlink:href="#gridicons-caption" />
+		<use xlink:href="gridicons.svg#gridicons-caption" />
 		</svg>
 		<p>gridicons-caption</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cart">
-		<use xlink:href="#gridicons-cart" />
+		<use xlink:href="gridicons.svg#gridicons-cart" />
 		</svg>
 		<p>gridicons-cart</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-chat">
-		<use xlink:href="#gridicons-chat" />
+		<use xlink:href="gridicons.svg#gridicons-chat" />
 		</svg>
 		<p>gridicons-chat</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-checkmark-circle">
-		<use xlink:href="#gridicons-checkmark-circle" />
+		<use xlink:href="gridicons.svg#gridicons-checkmark-circle" />
 		</svg>
 		<p>gridicons-checkmark-circle</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-checkmark">
-		<use xlink:href="#gridicons-checkmark" />
+		<use xlink:href="gridicons.svg#gridicons-checkmark" />
 		</svg>
 		<p>gridicons-checkmark</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-chevron-down">
-		<use xlink:href="#gridicons-chevron-down" />
+		<use xlink:href="gridicons.svg#gridicons-chevron-down" />
 		</svg>
 		<p>gridicons-chevron-down</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-chevron-left">
-		<use xlink:href="#gridicons-chevron-left" />
+		<use xlink:href="gridicons.svg#gridicons-chevron-left" />
 		</svg>
 		<p>gridicons-chevron-left</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-chevron-right">
-		<use xlink:href="#gridicons-chevron-right" />
+		<use xlink:href="gridicons.svg#gridicons-chevron-right" />
 		</svg>
 		<p>gridicons-chevron-right</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-chevron-up">
-		<use xlink:href="#gridicons-chevron-up" />
+		<use xlink:href="gridicons.svg#gridicons-chevron-up" />
 		</svg>
 		<p>gridicons-chevron-up</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-clear-formatting">
-		<use xlink:href="#gridicons-clear-formatting" />
+		<use xlink:href="gridicons.svg#gridicons-clear-formatting" />
 		</svg>
 		<p>gridicons-clear-formatting</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-clipboard">
-		<use xlink:href="#gridicons-clipboard" />
+		<use xlink:href="gridicons.svg#gridicons-clipboard" />
 		</svg>
 		<p>gridicons-clipboard</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cloud-download">
-		<use xlink:href="#gridicons-cloud-download" />
+		<use xlink:href="gridicons.svg#gridicons-cloud-download" />
 		</svg>
 		<p>gridicons-cloud-download</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cloud-outline">
-		<use xlink:href="#gridicons-cloud-outline" />
+		<use xlink:href="gridicons.svg#gridicons-cloud-outline" />
 		</svg>
 		<p>gridicons-cloud-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cloud-upload">
-		<use xlink:href="#gridicons-cloud-upload" />
+		<use xlink:href="gridicons.svg#gridicons-cloud-upload" />
 		</svg>
 		<p>gridicons-cloud-upload</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cloud">
-		<use xlink:href="#gridicons-cloud" />
+		<use xlink:href="gridicons.svg#gridicons-cloud" />
 		</svg>
 		<p>gridicons-cloud</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-code">
-		<use xlink:href="#gridicons-code" />
+		<use xlink:href="gridicons.svg#gridicons-code" />
 		</svg>
 		<p>gridicons-code</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cog">
-		<use xlink:href="#gridicons-cog" />
+		<use xlink:href="gridicons.svg#gridicons-cog" />
 		</svg>
 		<p>gridicons-cog</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-comment">
-		<use xlink:href="#gridicons-comment" />
+		<use xlink:href="gridicons.svg#gridicons-comment" />
 		</svg>
 		<p>gridicons-comment</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-computer">
-		<use xlink:href="#gridicons-computer" />
+		<use xlink:href="gridicons.svg#gridicons-computer" />
 		</svg>
 		<p>gridicons-computer</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-coupon">
-		<use xlink:href="#gridicons-coupon" />
+		<use xlink:href="gridicons.svg#gridicons-coupon" />
 		</svg>
 		<p>gridicons-coupon</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-create">
-		<use xlink:href="#gridicons-create" />
+		<use xlink:href="gridicons.svg#gridicons-create" />
 		</svg>
 		<p>gridicons-create</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-credit-card">
-		<use xlink:href="#gridicons-credit-card" />
+		<use xlink:href="gridicons.svg#gridicons-credit-card" />
 		</svg>
 		<p>gridicons-credit-card</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-crop">
-		<use xlink:href="#gridicons-crop" />
+		<use xlink:href="gridicons.svg#gridicons-crop" />
 		</svg>
 		<p>gridicons-crop</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cross-circle">
-		<use xlink:href="#gridicons-cross-circle" />
+		<use xlink:href="gridicons.svg#gridicons-cross-circle" />
 		</svg>
 		<p>gridicons-cross-circle</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cross-small">
-		<use xlink:href="#gridicons-cross-small" />
+		<use xlink:href="gridicons.svg#gridicons-cross-small" />
 		</svg>
 		<p>gridicons-cross-small</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-cross">
-		<use xlink:href="#gridicons-cross" />
+		<use xlink:href="gridicons.svg#gridicons-cross" />
 		</svg>
 		<p>gridicons-cross</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-custom-post-type">
-		<use xlink:href="#gridicons-custom-post-type" />
+		<use xlink:href="gridicons.svg#gridicons-custom-post-type" />
 		</svg>
 		<p>gridicons-custom-post-type</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-customize">
-		<use xlink:href="#gridicons-customize" />
+		<use xlink:href="gridicons.svg#gridicons-customize" />
 		</svg>
 		<p>gridicons-customize</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-domains">
-		<use xlink:href="#gridicons-domains" />
+		<use xlink:href="gridicons.svg#gridicons-domains" />
 		</svg>
 		<p>gridicons-domains</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-dropdown">
-		<use xlink:href="#gridicons-dropdown" />
+		<use xlink:href="gridicons.svg#gridicons-dropdown" />
 		</svg>
 		<p>gridicons-dropdown</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-ellipsis-circle">
-		<use xlink:href="#gridicons-ellipsis-circle" />
+		<use xlink:href="gridicons.svg#gridicons-ellipsis-circle" />
 		</svg>
 		<p>gridicons-ellipsis-circle</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-ellipsis">
-		<use xlink:href="#gridicons-ellipsis" />
+		<use xlink:href="gridicons.svg#gridicons-ellipsis" />
 		</svg>
 		<p>gridicons-ellipsis</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-external">
-		<use xlink:href="#gridicons-external" />
+		<use xlink:href="gridicons.svg#gridicons-external" />
 		</svg>
 		<p>gridicons-external</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-filter">
-		<use xlink:href="#gridicons-filter" />
+		<use xlink:href="gridicons.svg#gridicons-filter" />
 		</svg>
 		<p>gridicons-filter</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-flag">
-		<use xlink:href="#gridicons-flag" />
+		<use xlink:href="gridicons.svg#gridicons-flag" />
 		</svg>
 		<p>gridicons-flag</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-flip-horizontal">
-		<use xlink:href="#gridicons-flip-horizontal" />
+		<use xlink:href="gridicons.svg#gridicons-flip-horizontal" />
 		</svg>
 		<p>gridicons-flip-horizontal</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-flip-vertical">
-		<use xlink:href="#gridicons-flip-vertical" />
+		<use xlink:href="gridicons.svg#gridicons-flip-vertical" />
 		</svg>
 		<p>gridicons-flip-vertical</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-folder-multiple">
-		<use xlink:href="#gridicons-folder-multiple" />
+		<use xlink:href="gridicons.svg#gridicons-folder-multiple" />
 		</svg>
 		<p>gridicons-folder-multiple</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-folder">
-		<use xlink:href="#gridicons-folder" />
+		<use xlink:href="gridicons.svg#gridicons-folder" />
 		</svg>
 		<p>gridicons-folder</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-fullscreen-exit">
-		<use xlink:href="#gridicons-fullscreen-exit" />
+		<use xlink:href="gridicons.svg#gridicons-fullscreen-exit" />
 		</svg>
 		<p>gridicons-fullscreen-exit</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-fullscreen">
-		<use xlink:href="#gridicons-fullscreen" />
+		<use xlink:href="gridicons.svg#gridicons-fullscreen" />
 		</svg>
 		<p>gridicons-fullscreen</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-globe">
-		<use xlink:href="#gridicons-globe" />
+		<use xlink:href="gridicons.svg#gridicons-globe" />
 		</svg>
 		<p>gridicons-globe</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-grid">
-		<use xlink:href="#gridicons-grid" />
+		<use xlink:href="gridicons.svg#gridicons-grid" />
 		</svg>
 		<p>gridicons-grid</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-heading">
-		<use xlink:href="#gridicons-heading" />
+		<use xlink:href="gridicons.svg#gridicons-heading" />
 		</svg>
 		<p>gridicons-heading</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-heart-outline">
-		<use xlink:href="#gridicons-heart-outline" />
+		<use xlink:href="gridicons.svg#gridicons-heart-outline" />
 		</svg>
 		<p>gridicons-heart-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-heart">
-		<use xlink:href="#gridicons-heart" />
+		<use xlink:href="gridicons.svg#gridicons-heart" />
 		</svg>
 		<p>gridicons-heart</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-help-outline">
-		<use xlink:href="#gridicons-help-outline" />
+		<use xlink:href="gridicons.svg#gridicons-help-outline" />
 		</svg>
 		<p>gridicons-help-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-help">
-		<use xlink:href="#gridicons-help" />
+		<use xlink:href="gridicons.svg#gridicons-help" />
 		</svg>
 		<p>gridicons-help</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-history">
-		<use xlink:href="#gridicons-history" />
+		<use xlink:href="gridicons.svg#gridicons-history" />
 		</svg>
 		<p>gridicons-history</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-house">
-		<use xlink:href="#gridicons-house" />
+		<use xlink:href="gridicons.svg#gridicons-house" />
 		</svg>
 		<p>gridicons-house</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-image-multiple">
-		<use xlink:href="#gridicons-image-multiple" />
+		<use xlink:href="gridicons.svg#gridicons-image-multiple" />
 		</svg>
 		<p>gridicons-image-multiple</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-image">
-		<use xlink:href="#gridicons-image" />
+		<use xlink:href="gridicons.svg#gridicons-image" />
 		</svg>
 		<p>gridicons-image</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-indent-left">
-		<use xlink:href="#gridicons-indent-left" />
+		<use xlink:href="gridicons.svg#gridicons-indent-left" />
 		</svg>
 		<p>gridicons-indent-left</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-indent-right">
-		<use xlink:href="#gridicons-indent-right" />
+		<use xlink:href="gridicons.svg#gridicons-indent-right" />
 		</svg>
 		<p>gridicons-indent-right</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-info-outline">
-		<use xlink:href="#gridicons-info-outline" />
+		<use xlink:href="gridicons.svg#gridicons-info-outline" />
 		</svg>
 		<p>gridicons-info-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-info">
-		<use xlink:href="#gridicons-info" />
+		<use xlink:href="gridicons.svg#gridicons-info" />
 		</svg>
 		<p>gridicons-info</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-ink">
-		<use xlink:href="#gridicons-ink" />
+		<use xlink:href="gridicons.svg#gridicons-ink" />
 		</svg>
 		<p>gridicons-ink</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-institution">
-		<use xlink:href="#gridicons-institution" />
+		<use xlink:href="gridicons.svg#gridicons-institution" />
 		</svg>
 		<p>gridicons-institution</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-italic">
-		<use xlink:href="#gridicons-italic" />
+		<use xlink:href="gridicons.svg#gridicons-italic" />
 		</svg>
 		<p>gridicons-italic</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-layout-blocks">
-		<use xlink:href="#gridicons-layout-blocks" />
+		<use xlink:href="gridicons.svg#gridicons-layout-blocks" />
 		</svg>
 		<p>gridicons-layout-blocks</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-layout">
-		<use xlink:href="#gridicons-layout" />
+		<use xlink:href="gridicons.svg#gridicons-layout" />
 		</svg>
 		<p>gridicons-layout</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-link-break">
-		<use xlink:href="#gridicons-link-break" />
+		<use xlink:href="gridicons.svg#gridicons-link-break" />
 		</svg>
 		<p>gridicons-link-break</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-link">
-		<use xlink:href="#gridicons-link" />
+		<use xlink:href="gridicons.svg#gridicons-link" />
 		</svg>
 		<p>gridicons-link</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-list-checkmark">
-		<use xlink:href="#gridicons-list-checkmark" />
+		<use xlink:href="gridicons.svg#gridicons-list-checkmark" />
 		</svg>
 		<p>gridicons-list-checkmark</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-list-ordered">
-		<use xlink:href="#gridicons-list-ordered" />
+		<use xlink:href="gridicons.svg#gridicons-list-ordered" />
 		</svg>
 		<p>gridicons-list-ordered</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-list-unordered">
-		<use xlink:href="#gridicons-list-unordered" />
+		<use xlink:href="gridicons.svg#gridicons-list-unordered" />
 		</svg>
 		<p>gridicons-list-unordered</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-location">
-		<use xlink:href="#gridicons-location" />
+		<use xlink:href="gridicons.svg#gridicons-location" />
 		</svg>
 		<p>gridicons-location</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-lock">
-		<use xlink:href="#gridicons-lock" />
+		<use xlink:href="gridicons.svg#gridicons-lock" />
 		</svg>
 		<p>gridicons-lock</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-mail">
-		<use xlink:href="#gridicons-mail" />
+		<use xlink:href="gridicons.svg#gridicons-mail" />
 		</svg>
 		<p>gridicons-mail</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-mention">
-		<use xlink:href="#gridicons-mention" />
+		<use xlink:href="gridicons.svg#gridicons-mention" />
 		</svg>
 		<p>gridicons-mention</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-menu">
-		<use xlink:href="#gridicons-menu" />
+		<use xlink:href="gridicons.svg#gridicons-menu" />
 		</svg>
 		<p>gridicons-menu</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-menus">
-		<use xlink:href="#gridicons-menus" />
+		<use xlink:href="gridicons.svg#gridicons-menus" />
 		</svg>
 		<p>gridicons-menus</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-microphone">
-		<use xlink:href="#gridicons-microphone" />
+		<use xlink:href="gridicons.svg#gridicons-microphone" />
 		</svg>
 		<p>gridicons-microphone</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-minus-small">
-		<use xlink:href="#gridicons-minus-small" />
+		<use xlink:href="gridicons.svg#gridicons-minus-small" />
 		</svg>
 		<p>gridicons-minus-small</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-minus">
-		<use xlink:href="#gridicons-minus" />
+		<use xlink:href="gridicons.svg#gridicons-minus" />
 		</svg>
 		<p>gridicons-minus</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-money">
-		<use xlink:href="#gridicons-money" />
+		<use xlink:href="gridicons.svg#gridicons-money" />
 		</svg>
 		<p>gridicons-money</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-my-sites-horizon">
-		<use xlink:href="#gridicons-my-sites-horizon" />
+		<use xlink:href="gridicons.svg#gridicons-my-sites-horizon" />
 		</svg>
 		<p>gridicons-my-sites-horizon</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-my-sites">
-		<use xlink:href="#gridicons-my-sites" />
+		<use xlink:href="gridicons.svg#gridicons-my-sites" />
 		</svg>
 		<p>gridicons-my-sites</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-not-visible">
-		<use xlink:href="#gridicons-not-visible" />
+		<use xlink:href="gridicons.svg#gridicons-not-visible" />
 		</svg>
 		<p>gridicons-not-visible</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-notice-outline">
-		<use xlink:href="#gridicons-notice-outline" />
+		<use xlink:href="gridicons.svg#gridicons-notice-outline" />
 		</svg>
 		<p>gridicons-notice-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-notice">
-		<use xlink:href="#gridicons-notice" />
+		<use xlink:href="gridicons.svg#gridicons-notice" />
 		</svg>
 		<p>gridicons-notice</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-offline">
-		<use xlink:href="#gridicons-offline" />
+		<use xlink:href="gridicons.svg#gridicons-offline" />
 		</svg>
 		<p>gridicons-offline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-pages">
-		<use xlink:href="#gridicons-pages" />
+		<use xlink:href="gridicons.svg#gridicons-pages" />
 		</svg>
 		<p>gridicons-pages</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-pause">
-		<use xlink:href="#gridicons-pause" />
+		<use xlink:href="gridicons.svg#gridicons-pause" />
 		</svg>
 		<p>gridicons-pause</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-pencil">
-		<use xlink:href="#gridicons-pencil" />
+		<use xlink:href="gridicons.svg#gridicons-pencil" />
 		</svg>
 		<p>gridicons-pencil</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-phone">
-		<use xlink:href="#gridicons-phone" />
+		<use xlink:href="gridicons.svg#gridicons-phone" />
 		</svg>
 		<p>gridicons-phone</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-plugins">
-		<use xlink:href="#gridicons-plugins" />
+		<use xlink:href="gridicons.svg#gridicons-plugins" />
 		</svg>
 		<p>gridicons-plugins</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-plus-small">
-		<use xlink:href="#gridicons-plus-small" />
+		<use xlink:href="gridicons.svg#gridicons-plus-small" />
 		</svg>
 		<p>gridicons-plus-small</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-plus">
-		<use xlink:href="#gridicons-plus" />
+		<use xlink:href="gridicons.svg#gridicons-plus" />
 		</svg>
 		<p>gridicons-plus</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-popout">
-		<use xlink:href="#gridicons-popout" />
+		<use xlink:href="gridicons.svg#gridicons-popout" />
 		</svg>
 		<p>gridicons-popout</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-posts">
-		<use xlink:href="#gridicons-posts" />
+		<use xlink:href="gridicons.svg#gridicons-posts" />
 		</svg>
 		<p>gridicons-posts</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-print">
-		<use xlink:href="#gridicons-print" />
+		<use xlink:href="gridicons.svg#gridicons-print" />
 		</svg>
 		<p>gridicons-print</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-product-downloadable">
-		<use xlink:href="#gridicons-product-downloadable" />
+		<use xlink:href="gridicons.svg#gridicons-product-downloadable" />
 		</svg>
 		<p>gridicons-product-downloadable</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-product-external">
-		<use xlink:href="#gridicons-product-external" />
+		<use xlink:href="gridicons.svg#gridicons-product-external" />
 		</svg>
 		<p>gridicons-product-external</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-product-virtual">
-		<use xlink:href="#gridicons-product-virtual" />
+		<use xlink:href="gridicons.svg#gridicons-product-virtual" />
 		</svg>
 		<p>gridicons-product-virtual</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-product">
-		<use xlink:href="#gridicons-product" />
+		<use xlink:href="gridicons.svg#gridicons-product" />
 		</svg>
 		<p>gridicons-product</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-quote">
-		<use xlink:href="#gridicons-quote" />
+		<use xlink:href="gridicons.svg#gridicons-quote" />
 		</svg>
 		<p>gridicons-quote</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-read-more">
-		<use xlink:href="#gridicons-read-more" />
+		<use xlink:href="gridicons.svg#gridicons-read-more" />
 		</svg>
 		<p>gridicons-read-more</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-reader-follow">
-		<use xlink:href="#gridicons-reader-follow" />
+		<use xlink:href="gridicons.svg#gridicons-reader-follow" />
 		</svg>
 		<p>gridicons-reader-follow</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-reader-following">
-		<use xlink:href="#gridicons-reader-following" />
+		<use xlink:href="gridicons.svg#gridicons-reader-following" />
 		</svg>
 		<p>gridicons-reader-following</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-reader">
-		<use xlink:href="#gridicons-reader" />
+		<use xlink:href="gridicons.svg#gridicons-reader" />
 		</svg>
 		<p>gridicons-reader</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-reblog">
-		<use xlink:href="#gridicons-reblog" />
+		<use xlink:href="gridicons.svg#gridicons-reblog" />
 		</svg>
 		<p>gridicons-reblog</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-redo">
-		<use xlink:href="#gridicons-redo" />
+		<use xlink:href="gridicons.svg#gridicons-redo" />
 		</svg>
 		<p>gridicons-redo</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-refresh">
-		<use xlink:href="#gridicons-refresh" />
+		<use xlink:href="gridicons.svg#gridicons-refresh" />
 		</svg>
 		<p>gridicons-refresh</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-refund">
-		<use xlink:href="#gridicons-refund" />
+		<use xlink:href="gridicons.svg#gridicons-refund" />
 		</svg>
 		<p>gridicons-refund</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-reply">
-		<use xlink:href="#gridicons-reply" />
+		<use xlink:href="gridicons.svg#gridicons-reply" />
 		</svg>
 		<p>gridicons-reply</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-resize">
-		<use xlink:href="#gridicons-resize" />
+		<use xlink:href="gridicons.svg#gridicons-resize" />
 		</svg>
 		<p>gridicons-resize</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-rotate">
-		<use xlink:href="#gridicons-rotate" />
+		<use xlink:href="gridicons.svg#gridicons-rotate" />
 		</svg>
 		<p>gridicons-rotate</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-scheduled">
-		<use xlink:href="#gridicons-scheduled" />
+		<use xlink:href="gridicons.svg#gridicons-scheduled" />
 		</svg>
 		<p>gridicons-scheduled</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-search">
-		<use xlink:href="#gridicons-search" />
+		<use xlink:href="gridicons.svg#gridicons-search" />
 		</svg>
 		<p>gridicons-search</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-share-ios">
-		<use xlink:href="#gridicons-share-ios" />
+		<use xlink:href="gridicons.svg#gridicons-share-ios" />
 		</svg>
 		<p>gridicons-share-ios</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-share">
-		<use xlink:href="#gridicons-share" />
+		<use xlink:href="gridicons.svg#gridicons-share" />
 		</svg>
 		<p>gridicons-share</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-shipping">
-		<use xlink:href="#gridicons-shipping" />
+		<use xlink:href="gridicons.svg#gridicons-shipping" />
 		</svg>
 		<p>gridicons-shipping</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-sign-out">
-		<use xlink:href="#gridicons-sign-out" />
+		<use xlink:href="gridicons.svg#gridicons-sign-out" />
 		</svg>
 		<p>gridicons-sign-out</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-spam">
-		<use xlink:href="#gridicons-spam" />
+		<use xlink:href="gridicons.svg#gridicons-spam" />
 		</svg>
 		<p>gridicons-spam</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-speaker">
-		<use xlink:href="#gridicons-speaker" />
+		<use xlink:href="gridicons.svg#gridicons-speaker" />
 		</svg>
 		<p>gridicons-speaker</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-special-character">
-		<use xlink:href="#gridicons-special-character" />
+		<use xlink:href="gridicons.svg#gridicons-special-character" />
 		</svg>
 		<p>gridicons-special-character</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-star-outline">
-		<use xlink:href="#gridicons-star-outline" />
+		<use xlink:href="gridicons.svg#gridicons-star-outline" />
 		</svg>
 		<p>gridicons-star-outline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-star">
-		<use xlink:href="#gridicons-star" />
+		<use xlink:href="gridicons.svg#gridicons-star" />
 		</svg>
 		<p>gridicons-star</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-stats-alt">
-		<use xlink:href="#gridicons-stats-alt" />
+		<use xlink:href="gridicons.svg#gridicons-stats-alt" />
 		</svg>
 		<p>gridicons-stats-alt</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-stats">
-		<use xlink:href="#gridicons-stats" />
+		<use xlink:href="gridicons.svg#gridicons-stats" />
 		</svg>
 		<p>gridicons-stats</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-status">
-		<use xlink:href="#gridicons-status" />
+		<use xlink:href="gridicons.svg#gridicons-status" />
 		</svg>
 		<p>gridicons-status</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-strikethrough">
-		<use xlink:href="#gridicons-strikethrough" />
+		<use xlink:href="gridicons.svg#gridicons-strikethrough" />
 		</svg>
 		<p>gridicons-strikethrough</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-sync">
-		<use xlink:href="#gridicons-sync" />
+		<use xlink:href="gridicons.svg#gridicons-sync" />
 		</svg>
 		<p>gridicons-sync</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-tablet">
-		<use xlink:href="#gridicons-tablet" />
+		<use xlink:href="gridicons.svg#gridicons-tablet" />
 		</svg>
 		<p>gridicons-tablet</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-tag">
-		<use xlink:href="#gridicons-tag" />
+		<use xlink:href="gridicons.svg#gridicons-tag" />
 		</svg>
 		<p>gridicons-tag</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-text-color">
-		<use xlink:href="#gridicons-text-color" />
+		<use xlink:href="gridicons.svg#gridicons-text-color" />
 		</svg>
 		<p>gridicons-text-color</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-themes">
-		<use xlink:href="#gridicons-themes" />
+		<use xlink:href="gridicons.svg#gridicons-themes" />
 		</svg>
 		<p>gridicons-themes</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-thumbs-up">
-		<use xlink:href="#gridicons-thumbs-up" />
+		<use xlink:href="gridicons.svg#gridicons-thumbs-up" />
 		</svg>
 		<p>gridicons-thumbs-up</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-time">
-		<use xlink:href="#gridicons-time" />
+		<use xlink:href="gridicons.svg#gridicons-time" />
 		</svg>
 		<p>gridicons-time</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-trash">
-		<use xlink:href="#gridicons-trash" />
+		<use xlink:href="gridicons.svg#gridicons-trash" />
 		</svg>
 		<p>gridicons-trash</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-trophy">
-		<use xlink:href="#gridicons-trophy" />
+		<use xlink:href="gridicons.svg#gridicons-trophy" />
 		</svg>
 		<p>gridicons-trophy</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-types">
-		<use xlink:href="#gridicons-types" />
+		<use xlink:href="gridicons.svg#gridicons-types" />
 		</svg>
 		<p>gridicons-types</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-underline">
-		<use xlink:href="#gridicons-underline" />
+		<use xlink:href="gridicons.svg#gridicons-underline" />
 		</svg>
 		<p>gridicons-underline</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-undo">
-		<use xlink:href="#gridicons-undo" />
+		<use xlink:href="gridicons.svg#gridicons-undo" />
 		</svg>
 		<p>gridicons-undo</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-user-add">
-		<use xlink:href="#gridicons-user-add" />
+		<use xlink:href="gridicons.svg#gridicons-user-add" />
 		</svg>
 		<p>gridicons-user-add</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-user-circle">
-		<use xlink:href="#gridicons-user-circle" />
+		<use xlink:href="gridicons.svg#gridicons-user-circle" />
 		</svg>
 		<p>gridicons-user-circle</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-user">
-		<use xlink:href="#gridicons-user" />
+		<use xlink:href="gridicons.svg#gridicons-user" />
 		</svg>
 		<p>gridicons-user</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-video-camera">
-		<use xlink:href="#gridicons-video-camera" />
+		<use xlink:href="gridicons.svg#gridicons-video-camera" />
 		</svg>
 		<p>gridicons-video-camera</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-video">
-		<use xlink:href="#gridicons-video" />
+		<use xlink:href="gridicons.svg#gridicons-video" />
 		</svg>
 		<p>gridicons-video</p>
 	</div>
 	<div>
 		<svg width="24" height="24" class="gridicon gridicons-visible">
-		<use xlink:href="#gridicons-visible" />
+		<use xlink:href="gridicons.svg#gridicons-visible" />
 		</svg>
 		<p>gridicons-visible</p>
 	</div>


### PR DESCRIPTION
Use SVG for Everybody library to support IE browsers up to version 9.

Removes Gridicons SVG inline code and replaces it with the external reference.

IE 9:

![image](https://cloud.githubusercontent.com/assets/390760/22881948/2bc3e67a-f1e9-11e6-9538-2b666f9ced1c.png)
