### PR TITLE
New Icon: Next Page

### DIFF
--- a/svg/gridicons-next-page.svg
+++ b/svg/gridicons-next-page.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<path d="M3,5h18v4H3V5z M3,19h18v-4H3V19z M5,11H3v2h2V11z M9,11H7v2h2V11z M17,11h-2v2h2V11z M21,11h-2v2h2V11z M13,11h-2v2h2V11z"/>
+</svg>


### PR DESCRIPTION
Add a new icon for pagination representing the `<!--nextpage-->` tag.  This icon mimics the [gridicons-read-more](https://github.com/Automattic/gridicons/blob/master/svg/gridicons-read-more.svg) icon with the only difference being the dotted center line which copies the tag visualization in Calypso.  While the tag is supported in Calypso by entering `<!--nextpage-->` in the HTML tab, no icon currently exists.  This icon will be used by the WordPress Android and iOS apps in the format toolbar of the editor alongside the read more icon.

See the table below for comparison between the read more and next page icons.

Name | Icon | Calypso
-|-|-
Read More | ![ic_read_more](https://cloud.githubusercontent.com/assets/3827611/24528832/a2e7b282-1565-11e7-9f00-71e7c0987626.png) | ![im_read_more](https://cloud.githubusercontent.com/assets/3827611/24528968/454552be-1566-11e7-9a5a-09873b8b27e7.png)
Next Page | ![ic_next_page](https://cloud.githubusercontent.com/assets/3827611/24528825/9b0cc700-1565-11e7-9360-4132b9f37e01.png) | ![im_next_page](https://cloud.githubusercontent.com/assets/3827611/24528966/3fc9a074-1566-11e7-86ba-93c53fe4f1ea.png)