### PR TITLE
Docs: specified ideal resolutions and exception for my-sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ render() {
 * `size`: Number - (default: 24) set the size of the icon.
 * `onClick`: Function - (optional) if you need a click callback.
 
-**Notes**: the icon set is made to be used exactly at these pixel sizes: 12, 18, 24, 36, 48, 54, 72. However, `gridicon-my-sites` as it's a small-size version of the WordPress logo, shouldn't be used larger than 36px.
+**Notes**:
+
+* The icon set is made to be used exactly at these pixel sizes: 12, 18, 24, 36, 48, 54, 72.
+* `gridicon-my-sites` as it's a small-size version of the WordPress logo, shouldn't be used larger than 36px. If you need to use the WordPress logo in larger sizes, see the [Social Logos project](https://github.com/Automattic/social-logos).
 
 
 ## Icon Set Style Guidelines

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ render() {
 }
 ```
 
+**Notes**: the icon set is made to be used exactly at these pixel sizes: 12, 18, 24, 36, 48, 54, 72. However, `gridicon-my-sites` as it's a small-size version of the WordPress logo, shouldn't be used larger than 36px.
+
+
 #### Props
 
 * `icon`: String - the icon name.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The [Calypso](https://github.com/Automattic/wp-calypso/) / [WordPress.com](https
 
 Note that this component requires [react](https://www.npmjs.com/package/react) to be installed in your project.
 
-Gridicon renders a single svg icon based on an `icon` prop. It takes a size property but defaults to 24px. For greater sharpness, the icons should only be shown at either 18px, 24px, 36px or 48px. 
+Gridicon renders a single svg icon based on an `icon` prop. It takes a size property but defaults to 24px. For greater sharpness, the icons should only be shown at either 18px, 24px, 36px or 48px.
 
 There's a gallery with all the available icons in https://wpcalypso.wordpress.com/devdocs/design/gridicons.
 
@@ -23,14 +23,14 @@ render() {
 }
 ```
 
-**Notes**: the icon set is made to be used exactly at these pixel sizes: 12, 18, 24, 36, 48, 54, 72. However, `gridicon-my-sites` as it's a small-size version of the WordPress logo, shouldn't be used larger than 36px.
-
-
 #### Props
 
 * `icon`: String - the icon name.
 * `size`: Number - (default: 24) set the size of the icon.
 * `onClick`: Function - (optional) if you need a click callback.
+
+**Notes**: the icon set is made to be used exactly at these pixel sizes: 12, 18, 24, 36, 48, 54, 72. However, `gridicon-my-sites` as it's a small-size version of the WordPress logo, shouldn't be used larger than 36px.
+
 
 ## Icon Set Style Guidelines
 


### PR DESCRIPTION
After a discussion (puPv3-4jW-p2) we noticed we should be more clear about:

1. the ideal sizes of the icon set
2. that `gridicons-my-sites` is a special case of the WordPress logo, and shouldn't be used larger than 36px.

This PR edits the readme with this note:

> **Notes**: the icon set is made to be used exactly at these pixel sizes: 12, 18, 24, 36, 48, 54, 72. However, `gridicon-my-sites` as it's a small-size version of the WordPress logo, shouldn't be used larger than 36px.

/cc @mattmiklic 