### PR TITLE
Adopt React 15.5+ approach to PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "build/index.js",
     "build/example.js"
   ],
+  "dependencies": {
+      "prop-types": "^15.5.10"
+  },
   "devDependencies": {
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-syntax-jsx": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepublish": "npm run build"
   },
   "peerDependencies": {
-    "react": ">=14.x"
+    "react": "^15.3.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "main": "build/index.js",
   "scripts": {
     "build": "grunt --verbose",
@@ -19,7 +19,7 @@
     "build/example.js"
   ],
   "dependencies": {
-      "prop-types": "^15.5.10"
+      "prop-types": "^15.5.7"
   },
   "devDependencies": {
     "babel-plugin-add-module-exports": "^0.2.1",

--- a/sources/react/index-header.jsx
+++ b/sources/react/index-header.jsx
@@ -10,7 +10,8 @@ OR if you're looking to change now SVGs get output, you'll need to edit strings 
 /**
  * External dependencies
  */
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 
 export default class Gridicon extends PureComponent {
 


### PR DESCRIPTION
React 15.5+ [moved PropTypes out of the main `react` package and into a separate `prop-types` package](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes). I'm using `gridicons` for a project and it's now the last dependency that is still throwing off deprecation warnings.

This PR attempts to address. It builds without errors, and addresses the deprecation warnings in my project, but could use thorough testing by someone more familiar with this code and packaging up modules for npm (e.g. should `prop-types` be in `peerDependencies` or `dependencies` see [migration guide](https://github.com/reactjs/prop-types#migrating-from-reactproptypes)). We may have to bump React version to ^0.14.9.

A second commit cleans up some minor linting issues based on [the Calypso ESLint config](https://github.com/Automattic/eslint-config-wpcalypso).