### PR TITLE
Remove babel transform-runtime plugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -209,7 +209,6 @@ module.exports = function( grunt ) {
 				],
 				comments: false,
 				plugins: [
-					'transform-runtime',
 					'transform-class-properties',
 					'transform-export-extensions',
 					'add-module-exports',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "1.0.1-alpha.1",
+  "version": "1.1.0-alpha.1",
   "main": "build/index.js",
   "scripts": {
     "build": "grunt --verbose",
@@ -25,7 +25,6 @@
     "babel-plugin-transform-export-extensions": "^6.8.0",
     "babel-plugin-transform-react-display-name": "^6.8.0",
     "babel-plugin-transform-react-jsx": "^6.8.0",
-    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-stage-2": "^6.18.0",
     "babili": "0.0.10",


### PR DESCRIPTION
Fixes #212

I had copy pasta'd the Calypso config, and missed that https://babeljs.io/docs/plugins/transform-runtime/ requires a hard dependency of `babel-runtime`. I went ahead and removed it since I'm not sure if we need these polyfills

For testing convenience, I published this to `1.1.0-alpha.1`. So you can install this via: `npm install gridicons@next --save`

cc @aduth @sirbrillig 