### PR TITLE
PropTypes package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "prepublish": "npm run build"
   },
   "peerDependencies": {
-    "react": ">=14.x"
+    "react": ">=14.x",
+    "prop-types": "^15.5.10"
   },
   "repository": {
     "type": "git",

--- a/sources/react/index-header.jsx
+++ b/sources/react/index-header.jsx
@@ -10,7 +10,8 @@ OR if you're looking to change now SVGs get output, you'll need to edit strings 
 /**
  * External dependencies
  */
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 
 export default class Gridicon extends PureComponent {
 


### PR DESCRIPTION
Got a console warning when using Gridicons as a package that reads:

> Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs

This PR addresses that and moves PropTypes out of the React package and requires it as a "peerDependency".

*Note:* Not entirely sure if this & React should be `peerDependencies` vs. normal `dependencies`, but placed PropTypes there because React was already listed in that category.
