### PR TITLE
Build: Fix classname generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "2.0.1-alpha.1",
+  "version": "2.0.1",
   "main": "build/index.js",
   "scripts": {
     "build": "grunt --verbose",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "2.0.0",
+  "version": "2.0.1-alpha.1",
   "main": "build/index.js",
   "scripts": {
     "build": "grunt --verbose",

--- a/sources/react/index-header.jsx
+++ b/sources/react/index-header.jsx
@@ -132,7 +132,7 @@ export default class Gridicon extends PureComponent {
 	}
 
 	render() {
-		const { size, onClick, icon: iconProp, ...otherProps } = this.props;
+		const { size, onClick, icon: iconProp, className, ...otherProps } = this.props;
 		const icon = 'gridicons-' + iconProp;
 		const needsOffset = this.needsOffset( icon, size );
 		const needsOffsetX = this.needsOffsetX( icon, size );
@@ -143,7 +143,7 @@ export default class Gridicon extends PureComponent {
 		const iconClass = [
 			'gridicon',
 			icon,
-			this.props.className,
+			className,
 			needsOffset ? 'needs-offset' : false,
 			needsOffsetX ? 'needs-offset-x' : false,
 			needsOffsetY ? 'needs-offset-y' : false,


### PR DESCRIPTION
Fixes a regression from https://github.com/Automattic/gridicons/pull/226 where if we called
```jsx
<Gridicon icon="add-image" className="foo" />
```

The SVG would only have class `foo` and would be missing `gridicon` and the icon name.

See related: https://github.com/Automattic/wp-calypso/pull/15758