### PR TITLE
Bump to v2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "build/index.js",
   "scripts": {
     "build": "grunt --verbose",


### PR DESCRIPTION
This PR will update gridicons to v2.0.2.

@jancavan @folletto any notable changes since v2.0.1? Would it be possible to start keeping track of changes in a changelog. For example:

https://github.com/Automattic/eslint-plugin-wpcalypso/blob/master/CHANGELOG.md