### PR TITLE
Docs: updated NPM details, step by step.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This icon set uses a few automation scripts to ease the generation of new icons 
 Note: to proceed with this you need to have write authorization to npm.
 
 1. Create a new PR with updated `CHANGELOG.md` and updated version in `package.json` (i.e. `1.2.3-alpha.1`), see an example [here](https://github.com/Automattic/gridicons/pull/247).
-2. Pre-publish that PR branch on npm with `npm publish --tag next`.
+2. Pre-publish that PR branch on npm with `npm publish --tag next` [more info](https://docs.npmjs.com/getting-started/using-tags).
 3. Create a new PR in a repository using Gridicons (i.e. [Calypso](https://github.com/Automattic/wp-calypso)), see an example [here](https://github.com/Automattic/wp-calypso/pull/17601).
 4. Test if the new icons show up, and there are no regressions in the previous icons.
 5. If changes look good, remove postfix in the version (i.e. `1.2.3`).

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Note: to proceed with this you need to have write authorization to npm.
 
 1. Create a new PR with updated `CHANGELOG.md` and updated version in `package.json` (i.e. `1.2.3-alpha.1`), see an example [here](https://github.com/Automattic/gridicons/pull/247).
 2. Pre-publish that PR branch on npm with `npm publish --tag next` ([more info](https://docs.npmjs.com/cli/dist-tag)).
-3. Create a new update PR in a repository that makes use of Gridicons (i.e. [Calypso](https://github.com/Automattic/wp-calypso)) pointing `package.json` to the alpha version, see an example [here](https://github.com/Automattic/wp-calypso/pull/17601).
+3. Create a new update PR in a repository that makes use of Gridicons and run `npm install gridicons@next --save` (which will update `packages.json`). If you're creating the PR in [Calypso](https://github.com/Automattic/wp-calypso) and you get warnings, it might need to regenerate the shrinkwrap, in which case run `npm run update-deps`. See an example [here](https://github.com/Automattic/wp-calypso/pull/17601).
 4. Test if the new icons show up, and there are no regressions in the previous icons.
 5. If changes look good, remove the alpha postfix in the version (i.e. `1.2.3-alpha.1` to `1.2.3`) on both repositories PRs.
 6. Merge the Gridicons PR.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ These are not rules, they are guidelines that can be broken with the proper reas
 Note that the icons in this set are tied to be used in [Calypso](https://github.com/Automattic/wp-calypso/), but there might be exceptions for more general icons that make sense to be added.
 
 1. Make sure you have a updated local clone of the repository.
-2. Draw the icon in Illustrator on a 24px grid using the guidelines above (use [icon-template.ai](https://github.com/Automattic/gridicons/wiki/Icon-Template) as starting point).  
+2. Draw the icon in Illustrator on a 24px grid using the guidelines above (use [icon-template.ai](https://github.com/Automattic/gridicons/wiki/Icon-Template) as starting point).
    _Tip: tap CMD + Option + Y in Illustrator to see the pixel grid version._
 3. Submit a Pull Request with the icon as a SVG file (inside the `sources/svg` folder), make sure to include a screenshot, ideally containing side by side comparison with some other Gridicons as a visual reference.
 4. Discuss, iterate, review, refine until ready.
@@ -87,14 +87,14 @@ This icon set uses a few automation scripts to ease the generation of new icons 
 Note: to proceed with this you need to have write authorization to npm.
 
 1. Create a new PR with updated `CHANGELOG.md` and updated version in `package.json` (i.e. `1.2.3-alpha.1`), see an example [here](https://github.com/Automattic/gridicons/pull/247).
-2. Pre-publish that PR branch on npm with `npm publish --tag next` (more info).
+2. Pre-publish that PR branch on npm with `npm publish --tag next`.
 3. Create a new PR in a repository using Gridicons (i.e. [Calypso](https://github.com/Automattic/wp-calypso)), see an example [here](https://github.com/Automattic/wp-calypso/pull/17601).
 4. Test if the new icons show up, and there are no regressions in the previous icons.
-5. If changes look good remove postfix in the version (i.e. `1.2.3`).
+5. If changes look good, remove postfix in the version (i.e. `1.2.3`).
 6. Merge the Gridicons PR.
 7. Tag the release on GitHub: `git tag -a v1.2.3 -m "Release v1.2.3"` (and push `git push origin v1.2.3`).
-8. Check it shows up in the [Releases list](https://github.com/Automattic/gridicons/releases).
-8. Publish MASTER using the latest tag `npm publish --tag latest`.
+8. Check if it shows up in the [Releases list](https://github.com/Automattic/gridicons/releases).
+8. Publish to MASTER using the latest tag `npm publish --tag latest`.
 9. Merge the test repository PR.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This icon set uses a few automation scripts to ease the generation of new icons 
 Note: to proceed with this you need to have write authorization to npm.
 
 1. Create a new PR with updated `CHANGELOG.md` and updated version in `package.json` (i.e. `1.2.3-alpha.1`), see an example [here](https://github.com/Automattic/gridicons/pull/247).
-2. Pre-publish that PR branch on npm with `npm publish --tag next` ([more info])(https://docs.npmjs.com/getting-started/using-tags).
+2. Pre-publish that PR branch on npm with `npm publish --tag next` \([more info]\)(https://docs.npmjs.com/getting-started/using-tags).
 3. Create a new PR in a repository using Gridicons (i.e. [Calypso](https://github.com/Automattic/wp-calypso)), see an example [here](https://github.com/Automattic/wp-calypso/pull/17601).
 4. Test if the new icons show up, and there are no regressions in the previous icons.
 5. If changes look good, remove postfix in the version (i.e. `1.2.3`).

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This icon set uses a few automation scripts to ease the generation of new icons 
 Note: to proceed with this you need to have write authorization to npm.
 
 1. Create a new PR with updated `CHANGELOG.md` and updated version in `package.json` (i.e. `1.2.3-alpha.1`), see an example [here](https://github.com/Automattic/gridicons/pull/247).
-2. Pre-publish that PR branch on npm with `npm publish --tag next` \([more info]\)(https://docs.npmjs.com/getting-started/using-tags).
+2. Pre-publish that PR branch on npm with `npm publish --tag next` \(<a href="https://docs.npmjs.com/getting-started/using-tags">more info</a>\).
 3. Create a new PR in a repository using Gridicons (i.e. [Calypso](https://github.com/Automattic/wp-calypso)), see an example [here](https://github.com/Automattic/wp-calypso/pull/17601).
 4. Test if the new icons show up, and there are no regressions in the previous icons.
 5. If changes look good, remove postfix in the version (i.e. `1.2.3`).

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This icon set uses a few automation scripts to ease the generation of new icons 
 Note: to proceed with this you need to have write authorization to npm.
 
 1. Create a new PR with updated `CHANGELOG.md` and updated version in `package.json` (i.e. `1.2.3-alpha.1`), see an example [here](https://github.com/Automattic/gridicons/pull/247).
-2. Pre-publish that PR branch on npm with `npm publish --tag next` \(<a href="https://docs.npmjs.com/getting-started/using-tags">more info</a>\).
+2. Pre-publish that PR branch on npm with `npm publish --tag next` ([more info](https://docs.npmjs.com/cli/dist-tag)).
 3. Create a new PR in a repository using Gridicons (i.e. [Calypso](https://github.com/Automattic/wp-calypso)), see an example [here](https://github.com/Automattic/wp-calypso/pull/17601).
 4. Test if the new icons show up, and there are no regressions in the previous icons.
 5. If changes look good, remove postfix in the version (i.e. `1.2.3`).

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Note: to proceed with this you need to have write authorization to npm.
 6. Merge the Gridicons PR.
 7. Tag the release on GitHub: `git tag -a v1.2.3 -m "Release v1.2.3"` (and push `git push origin v1.2.3`).
 8. Check if it shows up in the [Releases list](https://github.com/Automattic/gridicons/releases).
-8. Publish to MASTER using the latest tag `npm publish --tag latest`.
+8. Publish to MASTER using the latest tag `npm publish`.
 9. Merge the test repository PR.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -82,14 +82,18 @@ Note that the icons in this set are tied to be used in [Calypso](https://github.
 This icon set uses a few automation scripts to ease the generation of new icons in a reliable way. In short, we require `node` and `grunt`. For detailed instructions check [the installation page](https://github.com/Automattic/gridicons/wiki/Installation).
 
 
-### Publishing to NPM
+## Publishing to npm
 
-- Follow install instructions
-- Check in changes if any and follow PR process.
-- Bump package version in package.json to the next desired version and add an alpha postfix `1.1.0-alpha.1`
-- While testing changes publish using the next tag `npm publish --tag next`
-- If changes look good remove postfix in the version `1.1.0`
-- Publish using the latest tag `npm publish --tag latest`
+Note: to proceed with this you need to have write authorization to npm.
+
+1. Create a new PR with updated `CHANGELOG.md` and updated version in `package.json` (i.e. `1.1.0-alpha.1`), see an example [here](https://github.com/Automattic/gridicons/pull/247).
+2. Pre-publish that PR branch on npm with `npm publish --tag next`.
+3. Create a new PR in a repository using Gridicons (i.e. [Calypso](https://github.com/Automattic/wp-calypso)), see an example [here](https://github.com/Automattic/wp-calypso/pull/17601).
+4. Test if the new icons show up, and there are no regressions in the previous icons.
+5. If changes look good remove postfix in the version (i.e. `1.1.0`).
+6. Merge the Gridicons PR.
+7. Publish MASTER using the latest tag `npm publish --tag latest`.
+8. Merge the test repository PR.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -86,14 +86,16 @@ This icon set uses a few automation scripts to ease the generation of new icons 
 
 Note: to proceed with this you need to have write authorization to npm.
 
-1. Create a new PR with updated `CHANGELOG.md` and updated version in `package.json` (i.e. `1.1.0-alpha.1`), see an example [here](https://github.com/Automattic/gridicons/pull/247).
-2. Pre-publish that PR branch on npm with `npm publish --tag next`.
+1. Create a new PR with updated `CHANGELOG.md` and updated version in `package.json` (i.e. `1.2.3-alpha.1`), see an example [here](https://github.com/Automattic/gridicons/pull/247).
+2. Pre-publish that PR branch on npm with `npm publish --tag next` (more info).
 3. Create a new PR in a repository using Gridicons (i.e. [Calypso](https://github.com/Automattic/wp-calypso)), see an example [here](https://github.com/Automattic/wp-calypso/pull/17601).
 4. Test if the new icons show up, and there are no regressions in the previous icons.
-5. If changes look good remove postfix in the version (i.e. `1.1.0`).
+5. If changes look good remove postfix in the version (i.e. `1.2.3`).
 6. Merge the Gridicons PR.
-7. Publish MASTER using the latest tag `npm publish --tag latest`.
-8. Merge the test repository PR.
+7. Tag the release on GitHub: `git tag -a v1.2.3 -m "Release v1.2.3"` (and push `git push origin v1.2.3`).
+8. Check it shows up in the [Releases list](https://github.com/Automattic/gridicons/releases).
+8. Publish MASTER using the latest tag `npm publish --tag latest`.
+9. Merge the test repository PR.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This icon set uses a few automation scripts to ease the generation of new icons 
 Note: to proceed with this you need to have write authorization to npm.
 
 1. Create a new PR with updated `CHANGELOG.md` and updated version in `package.json` (i.e. `1.2.3-alpha.1`), see an example [here](https://github.com/Automattic/gridicons/pull/247).
-2. Pre-publish that PR branch on npm with `npm publish --tag next` [more info](https://docs.npmjs.com/getting-started/using-tags).
+2. Pre-publish that PR branch on npm with `npm publish --tag next` ([more info])(https://docs.npmjs.com/getting-started/using-tags).
 3. Create a new PR in a repository using Gridicons (i.e. [Calypso](https://github.com/Automattic/wp-calypso)), see an example [here](https://github.com/Automattic/wp-calypso/pull/17601).
 4. Test if the new icons show up, and there are no regressions in the previous icons.
 5. If changes look good, remove postfix in the version (i.e. `1.2.3`).

--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ Note: to proceed with this you need to have write authorization to npm.
 
 1. Create a new PR with updated `CHANGELOG.md` and updated version in `package.json` (i.e. `1.2.3-alpha.1`), see an example [here](https://github.com/Automattic/gridicons/pull/247).
 2. Pre-publish that PR branch on npm with `npm publish --tag next` ([more info](https://docs.npmjs.com/cli/dist-tag)).
-3. Create a new PR in a repository using Gridicons (i.e. [Calypso](https://github.com/Automattic/wp-calypso)), see an example [here](https://github.com/Automattic/wp-calypso/pull/17601).
+3. Create a new update PR in a repository that makes use of Gridicons (i.e. [Calypso](https://github.com/Automattic/wp-calypso)) pointing `package.json` to the alpha version, see an example [here](https://github.com/Automattic/wp-calypso/pull/17601).
 4. Test if the new icons show up, and there are no regressions in the previous icons.
-5. If changes look good, remove postfix in the version (i.e. `1.2.3`).
+5. If changes look good, remove the alpha postfix in the version (i.e. `1.2.3-alpha.1` to `1.2.3`) on both repositories PRs.
 6. Merge the Gridicons PR.
 7. Tag the release on GitHub: `git tag -a v1.2.3 -m "Release v1.2.3"` (and push `git push origin v1.2.3`).
 8. Check if it shows up in the [Releases list](https://github.com/Automattic/gridicons/releases).
 8. Publish to MASTER using the latest tag `npm publish`.
-9. Merge the test repository PR.
+9. Merge the update PR in the other repository.
 
 ## License
 


### PR DESCRIPTION
More explicit step-by-step explanation to publish to npm.

Questions:

1. Is it thorough? If I know zero apart from initial Gridicons setup and I follow EXACTLY these steps, do I get the right outcome?
2. We mentioned using the npm support for github branches instead of `1.1.0-alpha.1` tag. I feel it's better, but I probably need a review to make sure I'm not writing bad instructions.
