### PR TITLE
Adds send-to-phone

### DIFF
--- a/sources/svg/gridicons-send-to-phone.svg
+++ b/sources/svg/gridicons-send-to-phone.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M10,15l4-3L10,9v2H3v2h7ZM16,2H8A2,2,0,0,0,6,4V9H8V5h8V19H8V15H6v5a2,2,0,0,0,2,2h8a2,2,0,0,0,2-2V4A2,2,0,0,0,16,2ZM13,20.94H11v-1h2Z"/></svg>


### PR DESCRIPTION
[Security2faProgress](https://github.com/Automattic/wp-calypso/tree/a70587157b33783ba4d5e0e4a1e136680d459d51/client/me/security-2fa-progress) uses three noticons to show 2FA progress. Two can be replaced with gridicons (phone and refresh) but send-to-phone is missing. 

<img width="361" alt="screen shot 2017-09-07 at 9 52 10 pm" src="https://user-images.githubusercontent.com/2627210/30162131-e0421390-9416-11e7-9815-93e1dd292001.png">



