### PR TITLE
Bump to v2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 _The versioning refers to the React component build._
 
+#### v2.0.5 (2017-10-16)
+* Icon updated: "Reply", flipped direction so it is pointing down and to the right.
+
 #### v2.0.4 (2017-09-20)
 * Icon added: "Gift"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "main": "build/index.js",
   "scripts": {
     "build": "grunt --verbose",


### PR DESCRIPTION
This PR updates Gridicons to v2.0.5 and updates changelog.md following this change: Automattic/gridicons#255