### PR TITLE
Build: regex-based <g> insertion matching svg tag, to be more reliable

### DIFF
--- a/grunt-tasks/svg-transform-add-g.js
+++ b/grunt-tasks/svg-transform-add-g.js
@@ -13,11 +13,8 @@ module.exports = function( grunt ) {
 			var fileContent = grunt.file.read( 'svg-min/' + svgFile );
 
 			// Add <g> to each file
-			fileContent = fileContent.slice( 0, fileContent.indexOf('viewBox="0 0 24 24">') + 20 ) +	// opening SVG tag
-						'<g>' +
-						fileContent.slice( fileContent.indexOf('viewBox="0 0 24 24">') + 20, -6 ) + 	// child elements of SVG
-						'</g>' +
-						fileContent.slice( -6 );	// closing SVG tag
+      fileContent = fileContent.replace( /<svg[^>]*>/i, '$&<g>' ); // add <g> after <svg>
+      fileContent = fileContent.replace( /<\/svg>/i, '</g>$&' ); // add </g> before </svg>
 
 			// Save and overwrite the files in svg-min
 			grunt.file.write( 'svg-min/' + svgFile, fileContent );


### PR DESCRIPTION
The previous `svg-transform-add-g` grunt task used a blind match on the string, relying on `viewBox="0 0 24 24">` to be at the end of the `<svg>` tag.

This PR updates the script to use a RegEx matching the `<svg>` tag in a more generic way:

* Start: `<svg[^>]*>` (matches anything inside the svg tag that is not a `>`, then gets the `>` as the ending of the tag)
* End: `</svg>` (escaping the `/`)

_This bug was found during testing of #256._ 

### To test

1. Delete `/svg-min` folder
2. Run grunt
3. Make sure no SVG that has been re-generated has any change (there should be any changed file in the git tracking)