### PR TITLE
React: Allow v16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 _The versioning refers to the React component build._
 
+#### v2.1.0 (2017-10-24)
+* React: Update example headers and footers to use `PureComponent` instead of `createClass`.
+* React: Allow version ^16.0.0.
+
 #### v2.0.5 (2017-10-16)
 * Icon updated: "Reply", flipped direction so it is pointing down and to the right.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 _The versioning refers to the React component build._
 
-#### v2.1.0 (2017-10-24)
+#### v2.1.0 (2017-10-25)
 * React: Update example headers and footers to use `PureComponent` instead of `createClass`.
 * React: Allow version ^16.0.0.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "2.1.0-alpha.2",
+  "version": "2.1.0",
   "main": "build/index.js",
   "scripts": {
     "build": "grunt --verbose",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "gridicons",
-  "version": "2.0.5",
+  "version": "2.1.0-alpha.1",
   "main": "build/index.js",
   "scripts": {
     "build": "grunt --verbose",
     "prepublish": "npm run build"
   },
   "peerDependencies": {
-    "react": "^15.3.0"
+    "react": "^15.3.0 || ^16.0.0 "
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "main": "build/index.js",
   "scripts": {
     "build": "grunt --verbose",

--- a/sources/react/example-footer.jsx
+++ b/sources/react/example-footer.jsx
@@ -1,6 +1,6 @@
 			</div>
 		);
 	}
-};
+}
 
 export default Gridicons;

--- a/sources/react/example-footer.jsx
+++ b/sources/react/example-footer.jsx
@@ -2,5 +2,3 @@
 		);
 	}
 }
-
-export default Gridicons;

--- a/sources/react/example-footer.jsx
+++ b/sources/react/example-footer.jsx
@@ -1,4 +1,6 @@
 			</div>
 		);
 	}
-} );
+};
+
+export default Gridicons;

--- a/sources/react/example-header.jsx
+++ b/sources/react/example-header.jsx
@@ -9,7 +9,9 @@ import React, { PureComponent } from 'react';
  */
 import Gridicon from './index.js';
 
-class Gridicons extends PureComponent {
+export default class Gridicons extends PureComponent {
+	static displayName = 'Gridicons'; // Don't remove, needed for Calypso devdocs!
+
 	handleClick = ( icon ) => {
 		const toCopy = '<Gridicon icon="' + icon + '" />';
 		window.prompt( 'Copy component code:', toCopy );

--- a/sources/react/example-header.jsx
+++ b/sources/react/example-header.jsx
@@ -2,19 +2,19 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { PureComponent } from 'react';
 
 /**
  * Internal dependencies
  */
 import Gridicon from './index.js';
-module.exports = React.createClass( {
-	displayName: 'Gridicons',
-	handleClick: function( icon ) {
-		var toCopy = '<Gridicon icon="' + icon + '" />';
-		window.prompt( 'Copy component code:', toCopy );
-	},
 
-	render: function() {
+class Gridicons extends PureComponent {
+	handleClick = ( icon ) => {
+		const toCopy = '<Gridicon icon="' + icon + '" />';
+		window.prompt( 'Copy component code:', toCopy );
+	};
+
+	render() {
 		return (
 			<div>


### PR DESCRIPTION
Only bumping the version to 2.1.0(-alpha.1, for now) since we're still permitting `^15.3.0`, too.

Relevant for https://github.com/Automattic/wp-calypso/pull/19083