### PR TITLE
Remove handlebars to get rid of security warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "grunt-rename": "^0.1.4",
     "grunt-svgmin": "^2.0.1",
     "grunt-svgstore": "^1.0.0",
-    "handlebars": "^2.0.0",
     "jit-grunt": "^0.10.0",
     "load-grunt-tasks": "^3.5.2",
     "xml2js": "^0.4.17",


### PR DESCRIPTION
We were seeing a security warning in this repo:

> The handlebars dependency defined in package.json has a known moderate severity security vulnerability in version range < 4.0.0 and should be updated.

This removes `handlebars` from `package.json` to eliminate that warning.