### PR TITLE
Bump to v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 _The versioning refers to the React component build._
 
+#### v2.1.1 (2017-12-12)
+* Icon added: "Zoom in"
+* Icon added: "Zoom out"
+
 #### v2.1.0 (2017-10-25)
 * React: Update example headers and footers to use `PureComponent` instead of `createClass`.
 * React: Allow version ^16.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 _The versioning refers to the React component build._
 
 #### v2.1.1 (2017-12-12)
-* Icon added: "Zoom in"
-* Icon added: "Zoom out"
+* Icon added: "Zoom In"
+* Icon added: "Zoom Out"
 
 #### v2.1.0 (2017-10-25)
 * React: Update example headers and footers to use `PureComponent` instead of `createClass`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "build/index.js",
   "scripts": {
     "build": "grunt --verbose",


### PR DESCRIPTION
Follow the recent change of adding Zoom in/out icons in this PR: https://github.com/Automattic/gridicons/pull/268, we need to update `package.json` and `changelog.md` to reflect the new version of Gridicons.