### PR TITLE
Docs: added missing "create" note in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 _The versioning refers to the React component build._
 
 #### v2.1.1 (2017-12-12)
+* Icon updated: "Create"
 * Icon added: "Zoom In"
 * Icon added: "Zoom Out"
 


### PR DESCRIPTION
In #269 we missed adding `create` (#256) that was added to Gridicons after `v2.1` (#260).