### PR TITLE
Docs: added missing icons in changelog for v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ _The versioning refers to the React component build._
 #### v2.1.0 (2017-10-25)
 * React: Update example headers and footers to use `PureComponent` instead of `createClass`.
 * React: Allow version ^16.0.0.
+* Icon updated: "image"
+* Icon updated: "video"
+* Icon added: "image-remove"
+* Icon added: "video-remove"
 
 #### v2.0.5 (2017-10-16)
 * Icon updated: "Reply", flipped direction so it is pointing down and to the right.


### PR DESCRIPTION
The React update in #260 also bumped the version at the same time without updating the changelog with all the changes happened from the previous version (v2.0.5, #257).