### PR TITLE
Docs: fixed date in 2.1.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 _The versioning refers to the React component build._
 
-#### v2.1.2 (2017-12-12)
+#### v2.1.2 (2018-01-23)
 * Icon added: "Plans"
 
 #### v2.1.1 (2017-12-12)


### PR DESCRIPTION
The date in the 2.1.2 changelog note was not correct, fixed to the date of the version bump.