### PR TITLE
Publish untranspiled React files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ node_modules/
 /npm-debug.log
 .idea/
 svg-min-react/
-esnext/
 cjs/
+esm/
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules/
 /npm-debug.log
 .idea/
 svg-min-react/
-build/
+esnext/
+cjs/
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 _The versioning refers to the React component build._
 
+#### v2.2.0 (2018-03-07)
+* Include untranspiled files in npm.
+
 #### v2.1.3 (2018-02-22)
 * Icon added: "Shutter"
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -98,10 +98,14 @@ module.exports = function( grunt ) {
 				]
 			},
 			dist: {
-				files: {
-					"build/index.js": "build/index.jsx",
-					"build/example.js": "build/example.jsx"
-				}
+				files: [{
+					expand: true,
+					cwd: 'esnext/',
+					src: [ '*.jsx' ],
+					dest: 'cjs/',
+					ext: '.js',
+					filter: 'isFile'
+				}]
 			}
 		},
 
@@ -143,7 +147,7 @@ module.exports = function( grunt ) {
           cwd: 'svg-min-react/',
           src: [ '**/*.svg' ],
           filter: 'isFile',
-          dest: 'build/'
+          dest: 'esnext/'
         }]
       }
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,7 +100,7 @@ module.exports = function( grunt ) {
 			dist: {
 				files: [{
 					expand: true,
-					cwd: 'esnext/',
+					cwd: 'esm/',
 					src: [ '*.jsx' ],
 					dest: 'cjs/',
 					ext: '.js',
@@ -147,7 +147,7 @@ module.exports = function( grunt ) {
           cwd: 'svg-min-react/',
           src: [ '**/*.svg' ],
           filter: 'isFile',
-          dest: 'esnext/'
+          dest: 'esm/'
         }]
       }
     },

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Note that the icons in this set are tied to be used in [Calypso](https://github.
 1. Switch to the branch (i.e. Pull Request) with the new icon.
 2. Review the SVG source of the new icons to make sure they are clean and readable.
 3. Check pixel sharpness: open in Illustrator (with "Pixel Preview") or Sketch (with "Show Pixels"), adjust if needed.
-4. Run `grunt` command from terminal. It will generate `svg-min`, React (`esnext` and `cjs`), `svg-sprite`, `pdf`, `php`, and `docs`.
+4. Run `grunt` command from terminal. It will generate `svg-min`, React (`esm` and `cjs`), `svg-sprite`, `pdf`, `php`, and `docs`.
 5. Commit
 6. Merge & delete branch
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Note that the icons in this set are tied to be used in [Calypso](https://github.
 1. Switch to the branch (i.e. Pull Request) with the new icon.
 2. Review the SVG source of the new icons to make sure they are clean and readable.
 3. Check pixel sharpness: open in Illustrator (with "Pixel Preview") or Sketch (with "Show Pixels"), adjust if needed.
-4. Run `grunt` command from terminal. It will generate `svg-min`, React (`build`), `svg-sprite`, `pdf`, `php`, and `docs`.
+4. Run `grunt` command from terminal. It will generate `svg-min`, React (`esnext` and `cjs`), `svg-sprite`, `pdf`, `php`, and `docs`.
 5. Commit
 6. Merge & delete branch
 
@@ -81,19 +81,19 @@ Note that the icons in this set are tied to be used in [Calypso](https://github.
 
 This icon set uses a few automation scripts to ease the generation of new icons in a reliable way. In short, we require `node` and `grunt`. For detailed instructions check [the installation page](https://github.com/Automattic/gridicons/wiki/Installation).
 
-Once you checkout the repo run `npm install` in the `gridicons` folder. 
-To generate all the fonts, svgs and so on you run `npm run build` 
+Once you checkout the repo run `npm install` in the `gridicons` folder.
+To generate all the fonts, svgs and so on you run `npm run build`
 
 ## Publishing to npm
 
 Note: to proceed with this you need to have write authorization to npm.
 
-1. Create a new PR with updated `CHANGELOG.md` and updated version in `package.json` (i.e. `1.2.3-alpha.1`), see an example [here](https://github.com/Automattic/gridicons/pull/275). 
-2. In the "CHANGELOG.md" make sure to check all the previous commits since the previous versioned release. 
+1. Create a new PR with updated `CHANGELOG.md` and updated version in `package.json` (i.e. `1.2.3-alpha.1`), see an example [here](https://github.com/Automattic/gridicons/pull/275).
+2. In the "CHANGELOG.md" make sure to check all the previous commits since the previous versioned release.
 3. Pre-publish that PR branch on npm with `npm publish --tag next` ([more info](https://docs.npmjs.com/cli/dist-tag)). Running the `npm publish --tag next` command will send the data that you have localy to npm. Having the alpha version in the `package.json` file will create a newly tagged version npm package. Use `npm view gridicons` to look at the list of current tags. You do not need to commit changes to github in order to publish to npm, but it is recommended so folks testing know what's available.
-4. Create a new update PR in a repository that makes use of Gridicons and run `npm install gridicons@next --save` (which will update `packages.json`). If you're creating the PR in [Calypso](https://github.com/Automattic/wp-calypso) and you get warnings, it might need to regenerate the shrinkwrap, in which case run `npm run update-deps`. See an example [here](https://github.com/Automattic/wp-calypso/pull/17601). 
+4. Create a new update PR in a repository that makes use of Gridicons and run `npm install gridicons@next --save` (which will update `packages.json`). If you're creating the PR in [Calypso](https://github.com/Automattic/wp-calypso) and you get warnings, it might need to regenerate the shrinkwrap, in which case run `npm run update-deps`. See an example [here](https://github.com/Automattic/wp-calypso/pull/17601).
 5. Test if the new icons show up, and there are no regressions in the previous icons. Take a look at the `http://calypso.localhost:3000/devdocs/design/gridicons` for example.
-6. If changes look good, remove the alpha postfix in the version (i.e. `1.2.3-alpha.1` to `1.2.3`) on both repositories PRs. 
+6. If changes look good, remove the alpha postfix in the version (i.e. `1.2.3-alpha.1` to `1.2.3`) on both repositories PRs.
 7. Merge the Gridicons PR.
 8. Tag the release on GitHub: `git tag -a v1.2.3 -m "Release v1.2.3"` (and push `git push origin v1.2.3`).
 9. Check if it shows up in the [Releases list](https://github.com/Automattic/gridicons/releases).
@@ -106,11 +106,11 @@ Gridicons is licensed under [GNU General Public License v2 (or later)](./LICENSE
 
 ## More notes on publishing to npm
 You need to have a npm user account. [Create one here](https://www.npmjs.com/signup).
-Once you have created it, set up the account on you machine via 
+Once you have created it, set up the account on you machine via
 $ `npm adduser`
 
-Setup the 2fa with npm 
-$ `npm profile enable-2fa` 
+Setup the 2fa with npm
+$ `npm profile enable-2fa`
 
-Now everytime before you can publish 
+Now everytime before you can publish
 You will be asked for a your [2FA code (OPT)](https://en.wikipedia.org/wiki/One-time_password)

--- a/grunt-tasks/svg-to-react.js
+++ b/grunt-tasks/svg-to-react.js
@@ -1,5 +1,5 @@
 // ****************************************************************************************************
-// Create React component (`svg-min-react/` --> `esnext/`)
+// Create React component (`svg-min-react/` --> `esm/`)
 
 module.exports = function( grunt ) {
   grunt.registerMultiTask( 'svg-to-react', 'Output a react component for SVGs', function() {

--- a/grunt-tasks/svg-to-react.js
+++ b/grunt-tasks/svg-to-react.js
@@ -1,5 +1,5 @@
 // ****************************************************************************************************
-// Create React component (`svg-min-react/` --> `build/`)
+// Create React component (`svg-min-react/` --> `esnext/`)
 
 module.exports = function( grunt ) {
   grunt.registerMultiTask( 'svg-to-react', 'Output a react component for SVGs', function() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "gridicons",
   "version": "2.1.3",
-  "main": "build/index.js",
+  "main": "cjs/index.js",
+  "esnext": "esnext/index.js",
   "scripts": {
     "build": "grunt --verbose",
     "prepublish": "npm run build"
@@ -15,8 +16,8 @@
   },
   "license": "GPL-2.0+",
   "files": [
-    "build/index.js",
-    "build/example.js"
+    "cjs/",
+    "esnext/"
   ],
   "dependencies": {
       "prop-types": "^15.5.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "2.1.3",
+  "version": "2.2.0-alpha.1",
   "main": "cjs/index.js",
   "esnext": "esm/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gridicons",
   "version": "2.1.3",
   "main": "cjs/index.js",
-  "esnext": "esnext/index.js",
+  "esnext": "esm/index.js",
   "scripts": {
     "build": "grunt --verbose",
     "prepublish": "npm run build"
@@ -17,7 +17,7 @@
   "license": "GPL-2.0+",
   "files": [
     "cjs/",
-    "esnext/"
+    "esm/"
   ],
   "dependencies": {
       "prop-types": "^15.5.7"


### PR DESCRIPTION
There are two build steps to go from SVG to transpiled JS:

* `svg-to-react` step: SVG -> JSX/ES6(+)
* `babel` step: JSX/ES6(+) -> ES5

Currently, we do all these things in the `build/` directory that we create on the fly, and use `package.json`'s `files` attribute to only publish the transpiled `*.js` files (omitting the untranspiled `*.jsx` ones). However, it can be sometimes useful to include the untranspiled code in the published npm as well. This PR is specifically motivated by this discussion: https://github.com/Automattic/gridicons/pull/283#discussion_r172838047

The `main` entrypoint in `package.json` is updated to `cjs/index.js`, and a new `esnext` entrypoint is added so that consumers will be able to import untranspiled files from there.

To test:
* Delete your `build/` directory, if necessary.
* Run `npm run build`.
* Verify that a `cjs` (CommonJS, i.e. ES5) and an `esnext` directory have been created.
  * `esnext` contains untranspiled `index.jsx` and `example.jsx`
  * `cjs` contains their transpiled counterparts

This should also be tested to still work with Calypso. I'll publish a prerelease for testing, as described by the [instructions](https://github.com/Automattic/gridicons#publishing-to-npm).

#hackweek