### PR TITLE
Fix/main gridicon component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 _The versioning refers to the React component build._
 
+#### v3.0.1 (2018-03-14)
+* React: Revert to use React.PureComponent in main Gridicon, as to not break backward compatibility.
+
 #### v3.0.0 (2018-03-14)
 * React: remove obsolete @ssr-ready pragma from components.
 * React: allow importing individual icons in CommonJS module formats.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "3.0.0",
+  "version": "3.0.1-alpha.1",
   "main": "dist/index.js",
   "files": [
     "dist/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "3.0.1-alpha.2",
+  "version": "3.0.1-alpha.3",
   "main": "dist/index.js",
   "files": [
     "dist/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "3.0.1-alpha.1",
+  "version": "3.0.1-alpha.2",
   "main": "dist/index.js",
   "files": [
     "dist/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "3.0.1-alpha.3",
+  "version": "3.0.1",
   "main": "dist/index.js",
   "files": [
     "dist/"

--- a/sources/react/template-all-icons.js
+++ b/sources/react/template-all-icons.js
@@ -1,52 +1,67 @@
-const toString = array => array.reduce( ( acc, item ) => ( acc = acc + "'" + item + "', " ), '' );
+const toString = array =>
+        array.reduce((acc, item) => (acc = acc + "'" + item + "', "), '');
 
-const prepareAllIcons = ( {
-	components,
-	iconsThatNeedOffset,
-	iconsThatNeedOffsetX,
-	iconsThatNeedOffsetY,
-} ) => `
+const prepareAllIcons = ({
+        components,
+        iconsThatNeedOffset,
+        iconsThatNeedOffsetX,
+        iconsThatNeedOffsetY,
+}) => `
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 
-export default function( { icon: iconProp, className, onClick, size = 24, ...otherProps } ) {
+export default class Gridicon extends PureComponent {
 
-	const iconsThatNeedOffset = [ ${ toString( iconsThatNeedOffset ) } ];
+	static defaultProps = {
+		size: 24
+	};
 
-	const iconsThatNeedOffsetX = [ ${ toString( iconsThatNeedOffsetX ) } ];
+	static propTypes = {
+		icon: PropTypes.string.isRequired,
+		size: PropTypes.number,
+		onClick: PropTypes.func,
+		className: PropTypes.string
+	};
 
-	const iconsThatNeedOffsetY = [ ${ toString( iconsThatNeedOffsetY ) } ];
+	render() {
 
-	const doesItNeedOffset = ( name, icons ) => icons.indexOf( name ) >= 0;
-	const isModulo18 = size => size % 18 === 0;
+		const iconsThatNeedOffset = [ ${toString(iconsThatNeedOffset)} ];
 
-	const icon = 'gridicons-' + iconProp;
-	const needsOffset = doesItNeedOffset( icon, iconsThatNeedOffset ) && isModulo18( size );
-	const needsOffsetX = doesItNeedOffset( icon, iconsThatNeedOffsetX ) && isModulo18( size );
-	const needsOffsetY = doesItNeedOffset( icon, iconsThatNeedOffsetY ) && isModulo18( size );
+		const iconsThatNeedOffsetX = [ ${toString(iconsThatNeedOffsetX)} ];
 
-	let svg;
-	const iconClass = [
-		'gridicon',
-		icon,
-		className,
-		needsOffset ? 'needs-offset' : false,
-		needsOffsetX ? 'needs-offset-x' : false,
-		needsOffsetY ? 'needs-offset-y' : false,
-	].filter( Boolean ).join( ' ' );
+		const iconsThatNeedOffsetY = [ ${toString(iconsThatNeedOffsetY)} ];
 
-	switch ( icon ) {
-		default:
-			svg = <svg height={ size } width={ size } { ...otherProps } />;
-			break;
+		const doesItNeedOffset = ( name, icons ) => icons.indexOf( name ) >= 0;
+		const isModulo18 = size => size % 18 === 0;
 
-		${ components }
+		const icon = 'gridicons-' + iconProp;
+		const needsOffset = doesItNeedOffset( icon, iconsThatNeedOffset ) && isModulo18( size );
+		const needsOffsetX = doesItNeedOffset( icon, iconsThatNeedOffsetX ) && isModulo18( size );
+		const needsOffsetY = doesItNeedOffset( icon, iconsThatNeedOffsetY ) && isModulo18( size );
 
+		let svg;
+		const iconClass = [
+			'gridicon',
+			icon,
+			className,
+			needsOffset ? 'needs-offset' : false,
+			needsOffsetX ? 'needs-offset-x' : false,
+			needsOffsetY ? 'needs-offset-y' : false,
+		].filter( Boolean ).join( ' ' );
+
+		switch ( icon ) {
+			default:
+				svg = <svg height={ size } width={ size } { ...otherProps } />;
+				break;
+
+			${components}
+		}
+
+		return ( svg );
 	}
-
-	return ( svg );
 }
 `;
 

--- a/sources/react/template-all-icons.js
+++ b/sources/react/template-all-icons.js
@@ -28,6 +28,8 @@ export default class Gridicon extends PureComponent {
 
 	render() {
 
+		const { size, onClick, icon: iconProp, className, ...otherProps } = this.props;
+
 		const iconsThatNeedOffset = [ ${toString(iconsThatNeedOffset)} ];
 
 		const iconsThatNeedOffsetX = [ ${toString(iconsThatNeedOffsetX)} ];

--- a/sources/react/template-all-icons.js
+++ b/sources/react/template-all-icons.js
@@ -13,6 +13,15 @@ const prepareAllIcons = ({
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
+const doesItNeedOffset = ( name, icons ) => icons.indexOf( name ) >= 0;
+const isModulo18 = size => size % 18 === 0;
+
+const iconsThatNeedOffset = [ ${toString(iconsThatNeedOffset)} ];
+
+const iconsThatNeedOffsetX = [ ${toString(iconsThatNeedOffsetX)} ];
+
+const iconsThatNeedOffsetY = [ ${toString(iconsThatNeedOffsetY)} ];
+
 export default class Gridicon extends PureComponent {
 
 	static defaultProps = {
@@ -27,17 +36,7 @@ export default class Gridicon extends PureComponent {
 	};
 
 	render() {
-
 		const { size, onClick, icon: iconProp, className, ...otherProps } = this.props;
-
-		const iconsThatNeedOffset = [ ${toString(iconsThatNeedOffset)} ];
-
-		const iconsThatNeedOffsetX = [ ${toString(iconsThatNeedOffsetX)} ];
-
-		const iconsThatNeedOffsetY = [ ${toString(iconsThatNeedOffsetY)} ];
-
-		const doesItNeedOffset = ( name, icons ) => icons.indexOf( name ) >= 0;
-		const isModulo18 = size => size % 18 === 0;
 
 		const icon = 'gridicons-' + iconProp;
 		const needsOffset = doesItNeedOffset( icon, iconsThatNeedOffset ) && isModulo18( size );


### PR DESCRIPTION
By changing the component to be a functional one in https://github.com/Automattic/gridicons/pull/283, we broke backward compatibility. That resulted in a break in icons that used the React ref to keep track of the DOM element.

This PR reverts it to a React.PureComponent.

### How to test

https://github.com/Automattic/wp-calypso/pull/23306 makes use of `3.0.1-alpha.3` and is a good testbed.
