### PR TITLE
try: publish 'svg-min' folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "3.1.1",
   "main": "dist/index.js",
   "files": [
-    "dist/"
+    "dist/",
+    "svg-min/"
   ],
   "scripts": {
     "build": "grunt --verbose",


### PR DESCRIPTION
It seems we have [use](https://github.com/Automattic/wp-calypso/pull/27158) [cases](https://github.com/Automattic/wp-calypso/pull/27186) for accessing raw svg files in Calypso instead of React components. Ideally I think they should be included in the `dist/` folder as well, let's iterate on that.