### PR TITLE
Add gridicons-child

### DIFF
--- a/sources/svg/gridicons-child.svg
+++ b/sources/svg/gridicons-child.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path d="M5,4H3v6c0,3.3,2.7,6,6,6h7.2l-2.6,2.6L15,20l5-5l-5-5l-1.4,1.4l2.6,2.6H9c-2.2,0-4-1.8-4-4"/></g></svg>


### PR DESCRIPTION
This is a PR to add an icon to indicate a child element.

Example:
<img width="375" alt="screenshot 2019-02-06 at 13 02 38" src="https://user-images.githubusercontent.com/36532468/52413139-a4efeb00-2ad8-11e9-8599-06fe0c5fc87b.png">

With similar gridicons:
<img width="228" alt="screenshot 2019-02-06 at 13 02 38" src="https://user-images.githubusercontent.com/36532468/52413069-6d813e80-2ad8-11e9-9a2b-d8b8ff83718e.png">