### PR TITLE
Update package.json: explicitly require pdfkit 0.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jit-grunt": "^0.10.0",
     "load-grunt-tasks": "^3.5.2",
     "xml2js": "^0.4.17",
-    "svg-to-pdfkit": "0.1.3"
+    "svg-to-pdfkit": "0.1.3",
+    "pdfkit": "0.8.3"
   }
 }


### PR DESCRIPTION
This fixes pdfkit to 0.8.3 and prevents the usage of 0.9.0, which causes a regeneration of the pdf icons that we don't want.

See #302 #303 #258 

### To test

1. Switch to this branch
2. Try `npm install` then `grunt`
3. Verify with `npm ls pdfkit` that the library version is `0.1.3` and pdfkit is `0.8.3`
4. Make sure no change happens on the generated files

_(Note: the "react" error in `npm ls` is not an issue)._