### PR TITLE
Add spritemap and offsets to package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 _The versioning refers to the React component build._
+### v3.3.0 (2019-04-18)
+* Include SVG spritemap (svg-sprite/gridicons.svg) in gridicons npm package.
+* Include offset configuration (sources/react/icons-offset) in gridicons npm package.
+
 ### v3.2.0 (2019-04-11)
 * Icon added: "site"
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,6 +76,10 @@ module.exports = function( grunt ) {
 			sprite: {
 				src: 'svg-sprite/gridicons.svg',
 				dest: 'docs/gridicons.svg'
+			},
+			offset: {
+				src: 'sources/react/icons-offset.js',
+				dest: 'dist/cjs/icons-offset.js'
 			}
 		},
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,7 +79,7 @@ module.exports = function( grunt ) {
 			},
 			offset: {
 				src: 'sources/react/icons-offset.js',
-				dest: 'dist/cjs/icons-offset.js'
+				dest: 'dist/util/icons-offset.js'
 			}
 		},
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "main": "dist/index.js",
   "files": [
     "dist/",
-    "sources/react/icons-offset.js",
     "svg-sprite/gridicons.svg"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "gridicons",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "main": "dist/index.js",
   "files": [
-    "dist/"
+    "dist/",
+    "sources/react/icons-offset.js",
+    "svg-sprite/gridicons.svg"
   ],
   "scripts": {
     "build": "grunt --verbose",


### PR DESCRIPTION
In Calypso, this will allow us to transition away from the SVG-in-JS icons to a better approach, making use of the spritemap with SVG external content.

The rest of the package is kept as-is, to maintain compatibility.

@blowery I think this is a good approach, but I'd like your input. It should be ok to include these files in the package and depend on them explicitly in Calypso, right?