### PR TITLE
Bump package to 3.3.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 _The versioning refers to the React component build._
-### v3.3.0 (2019-04-18)
+### v3.3.1 (2019-05-02)
+* Remove duplicate file from NPM package.
+
+### v3.3.0 (2019-05-02)
 * Include SVG spritemap (svg-sprite/gridicons.svg) in gridicons npm package.
 * Include offset configuration (sources/react/icons-offset) in gridicons npm package.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "main": "dist/index.js",
   "files": [
     "dist/",


### PR DESCRIPTION
This patch release pushes a new version that doesn't include a duplicated file.

The file was an artifact of a previous change, with the build process not cleaning it up, so there are no actual changes to the code in this PR.