### PR TITLE
Add React 19 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 _The versioning refers to the React component build._
 
-### Unreleased
+### v3.4.3 (2026-07-07)
 * React 19 support
 
 ### v3.4.2 (2023-03-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 _The versioning refers to the React component build._
 
+### Unreleased
+* React 19 support
+
 ### v3.4.2 (2023-03-16)
 * Icon added: "science"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "xml2js": "^0.4.17"
       },
       "peerDependencies": {
-        "react": "15 - 18"
+        "react": "15 - 19"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prepublish": "npm run build"
   },
   "peerDependencies": {
-    "react": "15 - 18"
+    "react": "15 - 19"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridicons",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "main": "dist/index.js",
   "files": [
     "dist/",


### PR DESCRIPTION
- Bump React in `peerDependencies` to 19.
- Bump package version v3.4.2 → v3.4.3

Gridicons use stable React APIs (`React.createElement`) and plain props defaults, which are compatible across old and new React.

Ran a simple test with AI just in case:

---

I ran a version matrix in a temp harness with:
- `react`/`react-dom` `15.3.0`
- `16.14.0`
- `17.0.2`
- `18.3.1`
- `19.2.0`

For each version, I rendered both:
- an individual icon component (`dist/add.js`)
- the main `Gridicon` export (`dist/index.js`)

using `react-dom/server.renderToStaticMarkup`, and verified SVG output.  
